### PR TITLE
Enrichment works when running results from Query Builder

### DIFF
--- a/src/cljs/imcljsold/filters.cljs
+++ b/src/cljs/imcljsold/filters.cljs
@@ -124,14 +124,14 @@
 (defn get-parts
   "Get all of the different parts of an intermine query and group them by type"
   [model query]
+  (.log js/console "query" query)
   (group-by :type
             (distinct
               (map (fn [path]
                      (assoc {}
                        :type (im-type model path)
                        :path (str (trim-path-to-class model path) ".id")
-                       :query {:select [(str (trim-path-to-class model path) ".id")]
-                               :where (:where query)}))
+                       :query (merge query {:select [(str (trim-path-to-class model path) ".id")]}) ))
                    (:select query)))))
 
 

--- a/src/cljs/imcljsold/filters.cljs
+++ b/src/cljs/imcljsold/filters.cljs
@@ -124,7 +124,6 @@
 (defn get-parts
   "Get all of the different parts of an intermine query and group them by type"
   [model query]
-  (.log js/console "query" query)
   (group-by :type
             (distinct
               (map (fn [path]


### PR DESCRIPTION
Queries generated for enrichment should include all parts of the query (such as constraint logic) rather than just :select and :where. Fixes issue #106 