### PR TITLE
Add :hide-code? option to constraint components and use for templates

### DIFF
--- a/src/cljs/bluegenes/components/templates/views.cljs
+++ b/src/cljs/bluegenes/components/templates/views.cljs
@@ -76,6 +76,7 @@
                         :value (:value con)
                         :op (:op con)
                         :code (:code con)
+                        :hide-code? true
                         :label? true
                         :lists (second (first @lists))
                         :on-change (fn [new-constraint]

--- a/src/cljs/bluegenes/components/ui/constraint.cljs
+++ b/src/cljs/bluegenes/components/ui/constraint.cljs
@@ -138,7 +138,7 @@
     [:div.input-group-btn.dropdown.constraint-operator
      [:button.btn.btn-default.dropdown-toggle
       {:data-toggle "dropdown"}
-      (str (constraint-label op) " ") [:span.caret]]
+      (str (constraint-label op) " ") [:span.caret {:style {:margin-left "5px"}}]]
      (let [path-class            (im-path/class model path)
            any-lists-with-class? (some? (some (fn [list] (= path-class (keyword (:type list)))) lists))
            disable-lists?        (and lists (not any-lists-with-class?))]
@@ -170,7 +170,9 @@
   :op   The operator of the constraint
   :on-change  A function to call with the new constraint
   :on-remove A function to call with the constraint is removed
-  :label?     If true then include the path as a label"
+  :label?     If true then include the path as a label
+  :hide-code?     If true then do not show the code letter
+  "
   (let [pv (subscribe [:current-possible-values path])]
     (create-class
       {:component-did-mount (fn []
@@ -178,7 +180,7 @@
                                 (dispatch [:cache/fetch-possible-values path])))
        :reagent-render (fn [& {:keys [lists model path value op code on-change
                                       on-select-list on-change-operator on-remove
-                                      on-blur label? possible-values typeahead?]}]
+                                      on-blur label? possible-values typeahead? hide-code?]}]
                          (let [class? (im-path/class? model path)
                                op     (or op (if class? "LOOKUP" "="))]
                            [:div.constraint-component
@@ -209,7 +211,7 @@
                                       :possible-values @pv
                                       :on-change (fn [val] (on-change {:path path :value val :op op :code code}))
                                       :on-blur (fn [val] (when on-blur (on-blur {:path path :value val :op op :code code})))])
-                             (when code [:span.constraint-label code])]
+                             (when (and code (not hide-code?)) [:span.constraint-label code])]
                             (when on-remove [:svg.icon.icon-bin
                                              {:on-click (fn [op] (on-remove {:path path :value value :op op}))}
                                              [:use {:xlinkHref "#icon-bin"}]


### PR DESCRIPTION
## PR authors: 
### Please describe your PR:

Allow constraint components to be configured to not show the constraint code. This is now used in the Templates section.

## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [ ] review a _minified_ build (e.g. `lein cljsbuild min once` + `lein run`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [ ] ID resolver + results preview
- [ ] Templates execute and show results
- [ ] Templates allow you to select lists AND type in identifiers
- [ ] Search (dropdown preview version)
- [ ] Search (full results page)
- [ ] Report page loads, including homologues and tools
- [ ] Region search

This is not an exhaustive list - if you spot something else strange please bring it up!
