### PR TITLE
Fix console errors - minor tidyup PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /resources/public/js/min
 /resources/public/vendor
 /resources/public/css
+/resources/public/tools
 config/**/*.edn
 .lein-failures
 out
@@ -14,4 +15,3 @@ node_modules
 .lein-repl-history
 .nrepl-port
 .DS_Store
-

--- a/less/site.less
+++ b/less/site.less
@@ -1,7 +1,6 @@
 @import "../resources/public/vendor/bootstrap/less/bootstrap";
 @import "../resources/public/vendor/bootstrap-material-design/less/bootstrap-material-design";
 @import "../resources/public/vendor/bootstrap/less/navs";
-@import "../resources/public/vendor/gridlex/dist/gridlix.min.css";
 @import "json-html";
 @import "components/icons";
 @import "components/progressbar";

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -136,7 +136,6 @@
   (fn [{db :db}]
     {:db (assoc db :fetching-assets? false)
      :dispatch-n [[:cache/fetch-organisms]
-                  [:saved-data/load-lists]
                   [:regions/select-all-feature-types]]}))
 
 (reg-event-fx
@@ -144,13 +143,13 @@
   (fn [{db :db}]
     (let [analytics-id (:googleAnalytics (js->clj js/serverVars :keywordize-keys true))
           analytics-enabled? (not (clojure.string/blank? analytics-id))]
-          (if analytics-enabled? 
+          (if analytics-enabled?
             ;;set tracker up if we have a tracking id
             (do
               (js/ga "create" analytics-id "auto")
               (js/ga "send" "pageview")
               (.info js/console "Google Analytics enabled. Tracking ID:" analytics-id))
-            ;;inobtrusive console message if there's no id  
+            ;;inobtrusive console message if there's no id
             (.info js/console "Google Analytics disabled. No tracking ID."))
     {:db (assoc db :google-analytics {:enabled? analytics-enabled? :analytics-id analytics-id})}
     )))

--- a/src/cljs/bluegenes/sections/querybuilder/subs.cljs
+++ b/src/cljs/bluegenes/sections/querybuilder/subs.cljs
@@ -14,11 +14,6 @@
     (get-in db [:qb :query-constraints])))
 
 (reg-sub
-  :qb/query-constraints
-  (fn [db]
-    (get-in db [:qb :query-constraints])))
-
-(reg-sub
   :qb/query-is-valid?
   (fn [db]
     (get-in db [:qb :query-is-valid?])))
@@ -85,4 +80,3 @@
   :qb/menu
   (fn [db]
     (get-in db [:qb :menu])))
-


### PR DESCRIPTION
## PR authors: 
### Please describe your PR:

We had a few errors popping up in the console when bluegenes loaded, mostly re-frame events/subs being called/defined in multiple places or being called when they didn't exist. This fixes most of them.

