### PR TITLE
Templates: Add a "view" button

### DIFF
--- a/less/components/templates.less
+++ b/less/components/templates.less
@@ -260,6 +260,10 @@
         border-bottom: solid 3px #ecebeb;
         .transitions;
 
+        :hover {
+            cursor: pointer;
+        }
+
         .title {
             font-size: 1.4em;
 
@@ -307,6 +311,17 @@
             -webkit-box-shadow: 0 2px 5px -1px rgba(0,0,0,0.33);
             -moz-box-shadow: 0 2px 5px -1px rgba(0,0,0,0.33);
             box-shadow: 0 2px 5px -1px rgba(0,0,0,0.33);
+
+            // remove pointer from selected template
+            :hover {
+                cursor: default;
+            }
+
+            .input-group {
+                :hover {
+                    cursor: pointer;
+                }
+            } 
         }
     }
 
@@ -326,7 +341,18 @@
             border-radius: 2px;
         }
     }
+
+    .view {
+        display: flex;
+        align-items: baseline;
+        justify-content: flex-start;
+        bottom: -27px;
+        position: relative;
+        border: none;
+        background-color: #eee;
+    }
 }
+
 @media (min-width:1200px) {
     .templates .template-filters {
         margin-top: -10px - @crazy-padding;

--- a/less/components/templates.less
+++ b/less/components/templates.less
@@ -349,7 +349,8 @@
         bottom: -27px;
         position: relative;
         border: none;
-        background-color: #eee;
+        background-color: #039BE5;
+        color: #FFFFFF;
     }
 }
 

--- a/src/cljs/bluegenes/components/templates/views.cljs
+++ b/src/cljs/bluegenes/components/templates/views.cljs
@@ -59,7 +59,7 @@
         (results-count-text results-preview))]]))
 
 (defn select-template-settings
-  "UI component to allow users to select template details, e.g. select a list to be in, lookup value grater than, less than, etc."
+  "UI component to allow users to select template details, e.g. select a list to be in, lookup value greater than, less than, etc."
   [selected-template]
   (let [service   (subscribe [:selected-template-service])
         row-count (subscribe [:template-chooser/count])
@@ -126,6 +126,7 @@
           [:div.body
            [select-template-settings selected-template]
            [preview-results]])
+        [:button.view "View >>"]
         [tags (:tags query)]
         ]])))
 


### PR DESCRIPTION
## PR authors: 
### Please describe your PR:
This addresses #197, which provides visual cues that a template section can be expanded.
- change the cursor to a pointer when hovering over the sections
- add a button to each section with the text "View >>"

## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [x] review a _minified_ build (e.g. `lein cljsbuild min once` + `lein run`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [x] ID resolver + results preview
- [x] Templates execute and show results
- [x] Templates allow you to select lists AND type in identifiers
- [x] Search (dropdown preview version)
- [x] Search (full results page)
- [x] Report page loads, including homologues and tools
- [x] Region search

This is not an exhaustive list - if you spot something else strange please bring it up!
