### PR TITLE
Use the mine name from the enrichment query when linking to report page

### DIFF
--- a/src/cljs/bluegenes/sections/results/events.cljs
+++ b/src/cljs/bluegenes/sections/results/events.cljs
@@ -99,7 +99,7 @@
        :dispatch-n [[:enrichment/enrich]
                     [:im-tables.main/replace-all-state
                      [:results :fortable]
-                     {:settings {:links {:vocab {:mine "flymine"}
+                     {:settings {:links {:vocab {:mine (name (:source (last (get-in db [:results :history]))))}
                                          :on-click (fn [val] (accountant/navigate! val))}}
                       :query query
                       :service (get-in db [:mines last-source :service])}]]})))
@@ -119,7 +119,7 @@
        :dispatch-n [[:enrichment/enrich]
                     [:im-tables.main/replace-all-state
                      [:results :fortable]
-                     {:settings {:links {:vocab {:mine "flymine"}
+                     {:settings {:links {:vocab {:mine (name (:source (last (get-in db [:results :history]))))}
                                          :on-click (fn [val] (accountant/navigate! val))}}
                       :query (get package :value)
                       :service (get-in db [:mines (:source package) :service])}]]})))


### PR DESCRIPTION
## PR authors: @joshkh
### Please describe your PR:

`flymine` was a hard coded value in the functions that add and retrieve from the enrichment history which is used when linking to the report page `/report/flymine/Gene/12345`. Now the value is dynamic.

Fixes issue #199 

## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [ ] review a _minified_ build (e.g. `lein cljsbuild min once` + `lein run`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [ ] ID resolver + results preview
- [ ] Templates execute and show results
- [ ] Templates allow you to select lists AND type in identifiers
- [ ] Search (dropdown preview version)
- [ ] Search (full results page)
- [ ] Report page loads, including homologues and tools
- [ ] Region search

This is not an exhaustive list - if you spot something else strange please bring it up!
