### PR TITLE
Josh usecase

### DIFF
--- a/less/components/querybuilder.less
+++ b/less/components/querybuilder.less
@@ -583,9 +583,14 @@ div.column-container {
 }
 
 .constraint-input {
+    input[type="text"] {
+        transition: .4s;
+    }
     .disabled {
         color: grey;
         fill: grey;
+        color: #666666;
+        background-color: #cccccc;
     }
 }
 //yes this is overly specific. Sorry, bootstrap is bad to

--- a/less/components/templates.less
+++ b/less/components/templates.less
@@ -13,6 +13,10 @@
     font-size: 2em;
 }
 
+.template-constraint-container {
+    margin-bottom: 10px;
+}
+
 .templates {
     .preview {
         max-width: 60vw;

--- a/less/components/templates.less
+++ b/less/components/templates.less
@@ -17,6 +17,10 @@
     margin-bottom: 10px;
 }
 
+.constraint-component-label {
+    font-weight: bold;
+}
+
 .templates {
     .preview {
         max-width: 60vw;

--- a/less/components/toggle.less
+++ b/less/components/toggle.less
@@ -4,6 +4,7 @@
     display: flex;
     align-items: center;
     justify-content: flex-end;
+    margin: 3px 5px;
 }
 
 .switch-status {
@@ -15,7 +16,7 @@
 
 .switch-label {
     padding-right: 6px;
-    font-weight: bold;
+    // font-weight: bold;
     font-size: 0.8em;
 }
 

--- a/less/components/toggle.less
+++ b/less/components/toggle.less
@@ -1,0 +1,82 @@
+/* The switch - the box around the slider */
+
+.switch-container {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+}
+
+.switch-status {
+    padding-left: 6px;
+    font-weight: bold;
+    font-size: 0.8em;
+    width: 30px;
+}
+
+.switch-label {
+    padding-right: 6px;
+    font-weight: bold;
+    font-size: 0.8em;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 47px;
+  height: 34px;
+  height: 20px;
+
+  /* Hide default HTML checkbox */
+  input {display:none;}
+
+  /* The slider */
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 15px;
+    width: 15px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+
+  input:checked + .slider {
+    background-color: #2196F3;
+  }
+
+  input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+  }
+
+  input:checked + .slider:before {
+    -webkit-transform: translateX(26px);
+    -ms-transform: translateX(26px);
+    transform: translateX(26px);
+  }
+
+  /* Rounded sliders */
+  .slider.round {
+    border-radius: 34px;
+  }
+
+  .slider.round:before {
+    border-radius: 50%;
+  }
+}
+
+
+

--- a/less/site.less
+++ b/less/site.less
@@ -18,6 +18,7 @@
 @import "components/templates";
 @import "components/alerts";
 @import "components/login";
+@import "components/toggle";
 @import "saved-data";
 @import "developer";
 @import "overrides";

--- a/src/cljs/bluegenes/components/enrichment/views.cljs
+++ b/src/cljs/bluegenes/components/enrichment/views.cljs
@@ -54,7 +54,7 @@
                  :data-placement "top"
                  :data-trigger   "hover"}
           ^{:key p-value}
-          [:span description]]]]
+          [:a description]]]]
        [:div.col-xs-4 [:span {:style {:font-size "0.8em"}} (.toExponential p-value 6)]]]]]))
 
 (defn has-text?

--- a/src/cljs/bluegenes/components/enrichment/views.cljs
+++ b/src/cljs/bluegenes/components/enrichment/views.cljs
@@ -20,8 +20,8 @@
 (def sidebar-hover (reagent/atom false))
 
 (defn popover-table []
-  (let [values         (subscribe [:enrichment/summary-values])
-        result         (first (:results @values))
+  (let [values (subscribe [:enrichment/summary-values])
+        result (first (:results @values))
         column-headers (:columnHeaders @values)]
     (fn [matches p-value]
       [:div.sidebar-popover
@@ -38,24 +38,39 @@
    [:svg.icon.icon-question
     [:use {:xlinkHref "#icon-question"}]]])
 
+(defn build-matches-query [query path-constraint identifier]
+  (update-in (js->clj (.parse js/JSON query) :keywordize-keys true) [:where]
+             conj {:path path-constraint
+                   :op "ONE OF"
+                   :values [identifier]}))
+
 (defn enrichment-result-row []
-  (fn [{:keys [description matches identifier p-value matches-query] :as row}
-       {:keys [pathConstraint] :as details}]
-    [:li.enrichment-item
-     {:on-mouse-enter (fn [] (dispatch [:enrichment/get-item-details identifier pathConstraint]))
-      :on-click       (fn []
-                        (dispatch [:results/add-to-history row details]))}
-     [:div.container-fluid
-      [:div.row
-       [:div.col-xs-2 matches]
-       [:div.col-xs-6
-        [popover
-         [:span {:data-content   [popover-table matches p-value]
-                 :data-placement "top"
-                 :data-trigger   "hover"}
-          ^{:key p-value}
-          [:a description]]]]
-       [:div.col-xs-4 [:span {:style {:font-size "0.8em"}} (.toExponential p-value 6)]]]]]))
+  (let [current-mine (subscribe [:current-mine-name])]
+    (fn [{:keys [description matches identifier p-value matches-query] :as row}
+         {:keys [pathConstraint] :as details}]
+      [:li.enrichment-item
+       {:on-mouse-enter (fn [] (dispatch [:enrichment/get-item-details identifier pathConstraint]))
+        :on-click (fn []
+                    (dispatch [:results/history+ {:source @current-mine
+                                                  :type :query
+                                                  :value (assoc
+                                                           (build-matches-query
+                                                            (:pathQuery details)
+                                                            (:pathConstraint details)
+                                                            identifier)
+                                                           :title identifier)}])
+                    #_(dispatch [:results/add-to-history row details]))}
+       [:div.container-fluid
+        [:div.row
+         [:div.col-xs-2 matches]
+         [:div.col-xs-6
+          [popover
+           [:span {:data-content [popover-table matches p-value]
+                   :data-placement "top"
+                   :data-trigger "hover"}
+            ^{:key p-value}
+            [:a description]]]]
+         [:div.col-xs-4 [:span {:style {:font-size "0.8em"}} (.toExponential p-value 6)]]]]])))
 
 (defn has-text?
   "Return true if a label contains a string"
@@ -75,7 +90,7 @@
      [:div.col-xs-4.p-val "p-value" [p-val-tooltip]]]]])
 
 (defn enrichment-results-preview []
-  (let [page-state  (reagent/atom {:page 0 :show 5})
+  (let [page-state (reagent/atom {:page 0 :show 5})
         text-filter (subscribe [:enrichment/text-filter])
         config (subscribe [:enrichment/enrichment-config])]
     (fn [[widget-name {:keys [results] :as details}]]
@@ -92,8 +107,8 @@
               [:span
                {:on-click (fn [] (swap! page-state update :page dec))
                 :title "View previous 5 enrichment results"} [:svg.icon.icon-chevron-left [:use {:xlinkHref "#icon-chevron-left"}]]]
-                ;;TODO: replace the > below with the svg icon when enrichment is fixed.
-                ;;[:svg.icon.icon-circle-right [:use {:xlinkHref "#icon-circle-right"}]]
+              ;;TODO: replace the > below with the svg icon when enrichment is fixed.
+              ;;[:svg.icon.icon-circle-right [:use {:xlinkHref "#icon-circle-right"}]]
               [:span
                {:on-click (fn [] (swap! page-state update :page inc))
                 :title "View next 5 enrichment results"} [:svg.icon.icon-chevron-right [:use {:xlinkHref "#icon-chevron-right"}]]]])]
@@ -103,9 +118,9 @@
              (map (fn [row] [enrichment-result-row row details])
                   (take (:show @page-state)
                         (filter
-                         (fn [{:keys [description]}]
-                           (has-text? @text-filter description))
-                         (drop (* (:page @page-state) (:show @page-state)) results)))))])))
+                          (fn [{:keys [description]}]
+                            (has-text? @text-filter description))
+                          (drop (* (:page @page-state) (:show @page-state)) results)))))])))
 
 (defn enrichment-results []
   (let [all-enrichment-results (subscribe [:enrichment/enrichment-results])
@@ -118,7 +133,7 @@
                 [:h4 "No Enrichment Widgets Available"])]
         [:div.demo
          [css-transition-group
-          {:transition-name          "fade"
+          {:transition-name "fade"
            :transition-enter-timeout 500
            :transition-leave-timeout 500}
           (map (fn [enrichment-response]
@@ -129,13 +144,13 @@
   (let [value (subscribe [:enrichment/text-filter])]
     [:label.text-filter "Filter enrichment results"
      [:input.form-control
-      {:type        "text"
-       :value       @value
-       :on-change   (fn [e]
-                      (let [value (.. e -target -value)]
-                        (if (or (= value "") (= value nil))
-                          (dispatch [:enrichment/set-text-filter nil])
-                          (dispatch [:enrichment/set-text-filter value]))))
+      {:type "text"
+       :value @value
+       :on-change (fn [e]
+                    (let [value (.. e -target -value)]
+                      (if (or (= value "") (= value nil))
+                        (dispatch [:enrichment/set-text-filter nil])
+                        (dispatch [:enrichment/set-text-filter value]))))
        :placeholder "Filter..."}]]))
 
 (defn enrichment-settings []
@@ -211,7 +226,7 @@
 
 (defn enrich []
   (let [query-parts (subscribe [:results/query-parts])
-        value       (subscribe [:enrichment/text-filter])]
+        value (subscribe [:enrichment/text-filter])]
     (fn []
       [:div.enrichment
        {:on-mouse-enter (fn [] (reset! sidebar-hover true))

--- a/src/cljs/bluegenes/components/enrichment/views.cljs
+++ b/src/cljs/bluegenes/components/enrichment/views.cljs
@@ -91,12 +91,12 @@
               ;;[:svg.icon.icon-circle-left [:use {:xlinkHref "#icon-circle-left"}]]
               [:span
                {:on-click (fn [] (swap! page-state update :page dec))
-                :title "View previous 5 enrichment results"} "<"]
+                :title "View previous 5 enrichment results"} [:svg.icon.icon-chevron-left [:use {:xlinkHref "#icon-chevron-left"}]]]
                 ;;TODO: replace the > below with the svg icon when enrichment is fixed.
                 ;;[:svg.icon.icon-circle-right [:use {:xlinkHref "#icon-circle-right"}]]
               [:span
                {:on-click (fn [] (swap! page-state update :page inc))
-                :title "View next 5 enrichment results"}">"]])]
+                :title "View next 5 enrichment results"} [:svg.icon.icon-chevron-right [:use {:xlinkHref "#icon-chevron-right"}]]]])]
           [:span [mini-loader "tiny"]])]
        (cond (seq (:results details)) enrichment-results-header)
        (into [:ul.enrichment-list]

--- a/src/cljs/bluegenes/components/icons.cljs
+++ b/src/cljs/bluegenes/components/icons.cljs
@@ -32,6 +32,16 @@
      [:rect.intermine-logo.lowlight {:x 8 :y 6 :width 7 :height 4 :fill "#bbb"}]
      [:rect.intermine-logo.lowlight {:x 8 :y 11 :width 7 :height 4 :fill "#bbb"}]]
 
+    [:symbol#icon-chevron-right {:view-box "0 0 14 32"}
+     [:title "chevron-right"]
+     [:path {:d "M4 6l-4 4 6 6-6 6 4 4 10-10-10-10z"}]]
+
+    [:symbol#icon-chevron-left {:view-box "0 0 14 32"}
+     [:title "chevron-left"]
+     [:path {:d "M14 10l-4-4-10 10 10 10 4-4-6-6 6-6z"}]]
+
+
+
     [:symbol#icon-document-list {:view-box "0 0 32 32"}
      [:title "document-list"]
      [:path {:d "M19 3v6.002c0 1.111 0.898 1.998 2.006 1.998h4.994v17.003c0 1.107-0.894 1.997-1.997 1.997h-15.005c-1.107 0-1.997-0.899-1.997-2.007v-22.985c0-1.109 0.899-2.007 2.009-2.007h9.991zM20 3v5.997c0 0.554 0.451 1.003 0.991 1.003h5.009l-6-7zM15 14v1h8v-1h-8zM10 13v3h3v-3h-3zM11 14v1h1v-1h-1zM10 18v3h3v-3h-3zM11 19v1h1v-1h-1zM15 19v1h8v-1h-8zM10 23v3h3v-3h-3zM11 24v1h1v-1h-1zM15 24v1h8v-1h-8z"}]]

--- a/src/cljs/bluegenes/components/idresolver/events.cljs
+++ b/src/cljs/bluegenes/components/idresolver/events.cljs
@@ -146,21 +146,23 @@
 (reg-event-fx ::save-list-success
               (fn [{db :db} [_ list-name object-type response]]
                 ; Get the summary fields for this object type (used to construct the query for the List Analysis page
-                (let [summary-fields (get-in db [:assets :summary-fields (get db :current-mine) (keyword object-type)])]
+                (let [{:keys [listName]} response
+                      summary-fields (get-in db [:assets :summary-fields (get db :current-mine) (keyword object-type)])]
                   {:db db
                    ; Navigate to the List Analysis page
-                   :navigate "results"
+                   ;:navigate "results"
                    :dispatch-n [
                                 ; Re-fetch our lists so that it shows in MyMine
                                 [:assets/fetch-lists]
-                                ; Set the query in the List Analysis page to use the new list
-                                [:results/set-query {:source (get db :current-mine)
-                                                     :type :query
-                                                     :value {:from object-type
-                                                             :select summary-fields
-                                                             :where [{:path object-type
-                                                                      :op "IN"
-                                                                      :value list-name}]}}]]})))
+                                ; Show the list results in the List Analysis page
+                                [:results/history+ {:source (get db :current-mine)
+                                                    :type :query
+                                                    :value {:title list-name
+                                                            :from object-type
+                                                            :select summary-fields
+                                                            :where [{:path object-type
+                                                                     :op "IN"
+                                                                     :value list-name}]}}]]})))
 
 (reg-event-db ::reset
               (fn [db [_ example-type example-text]]

--- a/src/cljs/bluegenes/components/idresolver/events_inplace.cljs
+++ b/src/cljs/bluegenes/components/idresolver/events_inplace.cljs
@@ -236,12 +236,10 @@
           object-type    (get-object-type db)
           summary-fields (get-in db [:assets :summary-fields current-mine object-type])
           results        (build-query ids object-type summary-fields)]
-      (cond-> {}
-              true (assoc :dispatch-n [[:results/set-query {:source (get db :current-mine)
-                                                            :type :query
-                                                            :value (:value results)}]
-                                       [:idresolver/fetch-preview results]])
-              navigate? (assoc :navigate (str "results"))))))
+      {:dispatch-n [[:results/history+ {:source (get db :current-mine)
+                                        :type :query
+                                        :value (:value results)}]
+                    [:idresolver/fetch-preview results]]})))
 
 
 

--- a/src/cljs/bluegenes/components/search/events.cljs
+++ b/src/cljs/bluegenes/components/search/events.cljs
@@ -163,10 +163,11 @@
           current-mine   (:current-mine db)
           summary-fields (get-in db [:assets :summary-fields current-mine (keyword object-type)])]
       {:db db
-       :dispatch [:results/set-query
+       :dispatch [:results/history+
                   {:source current-mine
                    :type :query
-                   :value {:from object-type
+                   :value {:title "Search Results"
+                           :from object-type
                            :select summary-fields
                            :where [{:path (str object-type ".id")
                                     :op "ONE OF"

--- a/src/cljs/bluegenes/components/search/views.cljs
+++ b/src/cljs/bluegenes/components/search/views.cljs
@@ -44,11 +44,10 @@
       [:h4 "Results for '" @(subscribe [:search-term]) "'" [results-count]]
 
       (cond (and @active-filter? @some-selected?)
-            [:a.cta {:href "/#/results"
-                     :on-click (fn [e]
+            [:a.cta {:on-click (fn [e]
                                  (ocall e :preventDefault)
-                                 (dispatch [:search/to-results])
-                                 (navigate! "/results"))} "View selected results in a table"])]
+                                 (dispatch [:search/to-results]))}
+             "View selected results in a table"])]
      ;;TODO: Does this even make sense? Only implement if we figure out a good behaviour
      ;; select all search results seems odd, as does the whole page.
      ; [:div [:label "Select all" [:input {:type "checkbox"

--- a/src/cljs/bluegenes/components/templates/events.cljs
+++ b/src/cljs/bluegenes/components/templates/events.cljs
@@ -10,16 +10,24 @@
 (def name->kw (comp keyword name))
 (def ns->vec (juxt ns->kw name->kw))
 
+; Predictable function used to filter active constraints
+(def not-disabled-predicate (comp (partial not= "OFF") :switched))
+
+(defn remove-switchedoff-constraints
+  "Filter the constraints of a query map and only keep those with a :switched value other than OFF"
+  [query]
+  (update query :where #(filter not-disabled-predicate %)))
+
 (reg-event-fx
   :template-chooser/choose-template
   (fn [{db :db} [_ id]]
     (let [query (get-in db [:assets :templates (ns->kw id) (name->kw id)])]
-      {:db         (update-in db [:components :template-chooser]
-                              assoc
-                              :selected-template query
-                              :selected-template-name id
-                              :selected-template-service (get-in db [:mines (ns->kw id) :service])
-                              :count nil)
+      {:db (update-in db [:components :template-chooser]
+                      assoc
+                      :selected-template query
+                      :selected-template-name id
+                      :selected-template-service (get-in db [:mines (ns->kw id) :service])
+                      :count nil)
        :dispatch-n [[:template-chooser/run-count]
                     [:template-chooser/fetch-preview]]
        })))
@@ -39,11 +47,11 @@
   :templates/send-off-query
   (fn [{db :db} [_]]
     (let [summary-fields (get-in db [:assets :summary-fields (keyword type)])]
-      {:db       db
+      {:db db
        :dispatch [:results/set-query
                   {:source (ns->kw (get-in db [:components :template-chooser :selected-template-name]))
-                   :type   :query
-                   :value  (get-in db [:components :template-chooser :selected-template])}]
+                   :type :query
+                   :value (remove-switchedoff-constraints (get-in db [:components :template-chooser :selected-template]))}]
        :navigate (str "results")})))
 
 (defn one-of? [col value] (some? (some #{value} col)))
@@ -58,10 +66,10 @@
   :template-chooser/replace-constraint
   (fn [{db :db} [_ index new-constraint]]
     (let [constraint-location [:components :template-chooser :selected-template :where index]
-          old-constraint      (get-in db constraint-location)]
+          old-constraint (get-in db constraint-location)]
       ; Only fetch the query results if the operator hasn't change from a LIST to a VALUE or vice versa
       (if (should-update? (:op old-constraint) (:op new-constraint))
-        {:db         (assoc-in db constraint-location new-constraint)
+        {:db (assoc-in db constraint-location new-constraint)
          :dispatch-n [[:template-chooser/run-count]
                       [:template-chooser/fetch-preview]]}
         {:db (-> db
@@ -93,14 +101,14 @@
 (reg-event-fx
   :template-chooser/fetch-preview
   (fn [{db :db}]
-    (let [query         (get-in db [:components :template-chooser :selected-template])
+    (let [query (remove-switchedoff-constraints (get-in db [:components :template-chooser :selected-template]))
           template-name (get-in db [:components :template-chooser :selected-template-name])
-          service       (get-in db [:mines (ns->kw template-name) :service])
-          count-chan    (fetch/table-rows service query {:size 5})
-          new-db        (update-in db [:components :template-chooser] assoc
-                                   :preview-chan count-chan
-                                   :fetching-preview? true)]
-      {:db                            new-db
+          service (get-in db [:mines (ns->kw template-name) :service])
+          count-chan (fetch/table-rows service query {:size 5})
+          new-db (update-in db [:components :template-chooser] assoc
+                            :preview-chan count-chan
+                            :fetching-preview? true)]
+      {:db new-db
        :im-chan {:chan count-chan
                  :on-success [:template-chooser/store-results-preview]}})))
 
@@ -114,14 +122,14 @@
 (reg-event-fx
   :template-chooser/run-count
   (fn [{db :db}]
-    (let [query         (get-in db [:components :template-chooser :selected-template])
+    (let [query (remove-switchedoff-constraints (get-in db [:components :template-chooser :selected-template]))
           template-name (get-in db [:components :template-chooser :selected-template-name])
-          service       (get-in db [:mines (ns->kw template-name) :service])
-          count-chan    (fetch/row-count
-                          service
-                          query)
-          new-db        (update-in db [:components :template-chooser] assoc
-                                   :count-chan count-chan
-                                   :counting? true)]
-      {:db                          new-db
+          service (get-in db [:mines (ns->kw template-name) :service])
+          count-chan (fetch/row-count
+                       service
+                       query)
+          new-db (update-in db [:components :template-chooser] assoc
+                            :count-chan count-chan
+                            :counting? true)]
+      {:db new-db
        :template-chooser/pipe-count count-chan})))

--- a/src/cljs/bluegenes/components/templates/events.cljs
+++ b/src/cljs/bluegenes/components/templates/events.cljs
@@ -48,11 +48,10 @@
   (fn [{db :db} [_]]
     (let [summary-fields (get-in db [:assets :summary-fields (keyword type)])]
       {:db db
-       :dispatch [:results/set-query
+       :dispatch [:results/history+
                   {:source (ns->kw (get-in db [:components :template-chooser :selected-template-name]))
                    :type :query
-                   :value (remove-switchedoff-constraints (get-in db [:components :template-chooser :selected-template]))}]
-       :navigate (str "results")})))
+                   :value (remove-switchedoff-constraints (get-in db [:components :template-chooser :selected-template]))}]})))
 
 (defn one-of? [col value] (some? (some #{value} col)))
 (defn should-update? [old-op new-op]

--- a/src/cljs/bluegenes/components/templates/views.cljs
+++ b/src/cljs/bluegenes/components/templates/views.cljs
@@ -76,7 +76,7 @@
            ; Only show editable constraints, but don't filter because we want the index!
            (->> (keep-indexed (fn [idx con] (if (:editable con) [idx con])) (:where @selected-template))
                 (map (fn [[idx {:keys [switched switchable] :as con}]]
-                       [:div
+                       [:div.template-constraint-container
                         [constraint
                          :model (:model @service)
                          :typeahead? false

--- a/src/cljs/bluegenes/components/templates/views.cljs
+++ b/src/cljs/bluegenes/components/templates/views.cljs
@@ -86,6 +86,7 @@
                          :code (:code con)
                          :hide-code? true
                          :label? true
+                         :disabled (= switched "OFF")
                          :lists (second (first @lists))
                          :on-change (fn [new-constraint]
                                       (dispatch [:template-chooser/replace-constraint

--- a/src/cljs/bluegenes/components/templates/views.cljs
+++ b/src/cljs/bluegenes/components/templates/views.cljs
@@ -140,7 +140,7 @@
                             ; Same for left arrows
                             (re-find #"<-{1,}" part) [:svg.icon.icon-arrow-left [:use {:xlinkHref "#icon-arrow-left"}]]
                             ; Otherwise just return the section of text within a span
-                            :else [:span part])))))
+                            :else [:span (str part " ")])))))
         [:div.description
          {:dangerouslySetInnerHTML {:__html (:description query)}}]
         (if (= (name id) (:name @selected-template))

--- a/src/cljs/bluegenes/components/templates/views.cljs
+++ b/src/cljs/bluegenes/components/templates/views.cljs
@@ -56,6 +56,15 @@
         "Loading"
         (results-count-text results-preview))]]))
 
+(defn toggle []
+  (fn [{:keys [status on-change]}]
+    [:div.switch-container
+     [:span.switch-label "Optional"]
+     [:span.switch
+      [:input {:type "checkbox" :checked (case status "ON" true "OFF" false false)}]
+      [:span.slider.round {:on-click on-change}]]
+     [:span.switch-status status]]))
+
 (defn select-template-settings
   "UI component to allow users to select template details, e.g. select a list to be in, lookup value greater than, less than, etc."
   [selected-template]
@@ -66,20 +75,26 @@
      (into [:form.form]
            ; Only show editable constraints, but don't filter because we want the index!
            (->> (keep-indexed (fn [idx con] (if (:editable con) [idx con])) (:where @selected-template))
-                (map (fn [[idx con]]
-                       [constraint
-                        :model (:model @service)
-                        :typeahead? false
-                        :path (:path con)
-                        :value (:value con)
-                        :op (:op con)
-                        :code (:code con)
-                        :hide-code? true
-                        :label? true
-                        :lists (second (first @lists))
-                        :on-change (fn [new-constraint]
-                                     (dispatch [:template-chooser/replace-constraint
-                                                idx (merge con new-constraint)]))]))))]))
+                (map (fn [[idx {:keys [switched switchable] :as con}]]
+                       [:div
+                        [constraint
+                         :model (:model @service)
+                         :typeahead? false
+                         :path (:path con)
+                         :value (:value con)
+                         :op (:op con)
+                         :code (:code con)
+                         :hide-code? true
+                         :label? true
+                         :lists (second (first @lists))
+                         :on-change (fn [new-constraint]
+                                      (dispatch [:template-chooser/replace-constraint
+                                                 idx (merge con new-constraint)]))]
+                        (when switchable
+                          [toggle {:status switched
+                                   :on-change (fn [new-constraint]
+                                                (dispatch [:template-chooser/replace-constraint
+                                                           idx (assoc con :switched (case switched "ON" "OFF" "ON"))]))}])]))))]))
 
 (defn tags
   "UI element to visually output all aspect tags into each template card for easy scanning / identification of tags.

--- a/src/cljs/bluegenes/components/templates/views.cljs
+++ b/src/cljs/bluegenes/components/templates/views.cljs
@@ -83,6 +83,7 @@
                          :path (:path con)
                          :value (:value con)
                          :op (:op con)
+                         :label (s/join " > " (take-last 2 (s/split (im-path/friendly (:model @service) (:path con)) #" > ")))
                          :code (:code con)
                          :hide-code? true
                          :label? true

--- a/src/cljs/bluegenes/components/ui/constraint.cljs
+++ b/src/cljs/bluegenes/components/ui/constraint.cljs
@@ -100,12 +100,15 @@
   []
   (let [component (reagent/atom nil)
         focused?  (reagent/atom false)]
-    (fn [& {:keys [model path value typeahead? on-change on-blur allow-possible-values possible-values]}]
+    (fn [& {:keys [disabled model path value typeahead? on-change on-blur
+                   allow-possible-values possible-values disabled]}]
       [:div.constraint-text-input
        {:ref (fn [e] (reset! component e))
         :class (when @focused? "open")}
        [:input.form-control.dropdown
         {:data-toggle "none"
+         :disabled disabled
+         :class (when disabled "disabled")
          :type "text"
          :on-focus (fn [e] (reset! focused? true))
          :on-change (fn [e] (on-change (oget e :target :value)))
@@ -148,10 +151,10 @@
   :on-change  A function to call with the new operator
   :lists      (Optional) if provided, automatically disable list constraints
               if there are no lists of that type"
-  (fn [& {:keys [model path op on-change lists]}]
+  (fn [& {:keys [model path op on-change lists disabled]}]
     [:div.input-group-btn.dropdown.constraint-operator
      [:button.btn.btn-default.dropdown-toggle
-      {:data-toggle "dropdown"}
+      {:data-toggle "dropdown" :disabled disabled}
       (str (constraint-label op) " ") [:span.caret {:style {:margin-left "5px"}}]]
      (let [path-class            (im-path/class model path)
            any-lists-with-class? (some? (some (fn [list] (= path-class (keyword (:type list)))) lists))
@@ -194,7 +197,8 @@
                                 (dispatch [:cache/fetch-possible-values path])))
        :reagent-render (fn [& {:keys [lists model path value op code on-change
                                       on-select-list on-change-operator on-remove
-                                      on-blur label? possible-values typeahead? hide-code?]}]
+                                      on-blur label? possible-values typeahead? hide-code?
+                                      disabled]}]
                          (let [class? (im-path/class? model path)
                                op (or op (if class? "LOOKUP" "="))]
                            [:div.constraint-component
@@ -202,6 +206,7 @@
                              [constraint-operator
                               :model model
                               :path path
+                              :disabled disabled
                               ; Default to an OP if one has not been given
                               :op op
                               :lists lists
@@ -212,6 +217,7 @@
                                    (= op "NOT IN")) [list-dropdown
                                                      :value value
                                                      :lists lists
+                                                     :disabled disabled
                                                      :restrict-type (im-path/class model path)
                                                      :on-change (fn [list]
                                                                   ((or on-select-list on-change) {:path path :value list :code code :op op}))]
@@ -221,6 +227,7 @@
                                       :value value
                                       :typeahead? typeahead?
                                       :path path
+                                      :disabled disabled
                                       :allow-possible-values (and (not= op "IN") (not= op "NOT IN"))
                                       :possible-values @pv
                                       :on-change (fn [val] (on-change {:path path :value val :op op :code code}))

--- a/src/cljs/bluegenes/components/ui/constraint.cljs
+++ b/src/cljs/bluegenes/components/ui/constraint.cljs
@@ -212,7 +212,7 @@
                               :lists lists
                               :on-change (fn [op] ((or on-change-operator on-change) {:code code :path path :value value :op op}))]
                              [:div
-                              [:span label]
+                              [:span.constraint-component-label label]
                               (cond
                                 ; If this is a LIST constraint then show a list dropdown
                                 (or (= op "IN")

--- a/src/cljs/bluegenes/components/ui/constraint.cljs
+++ b/src/cljs/bluegenes/components/ui/constraint.cljs
@@ -202,7 +202,7 @@
                          (let [class? (im-path/class? model path)
                                op (or op (if class? "LOOKUP" "="))]
                            [:div.constraint-component
-                            [:div.input-group
+                            [:div.input-group.constraint-input
                              [constraint-operator
                               :model model
                               :path path

--- a/src/cljs/bluegenes/components/ui/constraint.cljs
+++ b/src/cljs/bluegenes/components/ui/constraint.cljs
@@ -198,7 +198,7 @@
        :reagent-render (fn [& {:keys [lists model path value op code on-change
                                       on-select-list on-change-operator on-remove
                                       on-blur label? possible-values typeahead? hide-code?
-                                      disabled]}]
+                                      disabled label]}]
                          (let [class? (im-path/class? model path)
                                op (or op (if class? "LOOKUP" "="))]
                            [:div.constraint-component
@@ -211,27 +211,29 @@
                               :op op
                               :lists lists
                               :on-change (fn [op] ((or on-change-operator on-change) {:code code :path path :value value :op op}))]
-                             (cond
-                               ; If this is a LIST constraint then show a list dropdown
-                               (or (= op "IN")
-                                   (= op "NOT IN")) [list-dropdown
-                                                     :value value
-                                                     :lists lists
-                                                     :disabled disabled
-                                                     :restrict-type (im-path/class model path)
-                                                     :on-change (fn [list]
-                                                                  ((or on-select-list on-change) {:path path :value list :code code :op op}))]
-                               ; Otherwise show a text input
-                               :else [constraint-text-input
-                                      :model model
-                                      :value value
-                                      :typeahead? typeahead?
-                                      :path path
-                                      :disabled disabled
-                                      :allow-possible-values (and (not= op "IN") (not= op "NOT IN"))
-                                      :possible-values @pv
-                                      :on-change (fn [val] (on-change {:path path :value val :op op :code code}))
-                                      :on-blur (fn [val] (when on-blur (on-blur {:path path :value val :op op :code code})))])
+                             [:div
+                              [:span label]
+                              (cond
+                                ; If this is a LIST constraint then show a list dropdown
+                                (or (= op "IN")
+                                    (= op "NOT IN")) [list-dropdown
+                                                      :value value
+                                                      :lists lists
+                                                      :disabled disabled
+                                                      :restrict-type (im-path/class model path)
+                                                      :on-change (fn [list]
+                                                                   ((or on-select-list on-change) {:path path :value list :code code :op op}))]
+                                ; Otherwise show a text input
+                                :else [constraint-text-input
+                                       :model model
+                                       :value value
+                                       :typeahead? typeahead?
+                                       :path path
+                                       :disabled disabled
+                                       :allow-possible-values (and (not= op "IN") (not= op "NOT IN"))
+                                       :possible-values @pv
+                                       :on-change (fn [val] (on-change {:path path :value val :op op :code code}))
+                                       :on-blur (fn [val] (when on-blur (on-blur {:path path :value val :op op :code code})))])]
                              (when (and code (not hide-code?)) [:span.constraint-label code])]
                             (when on-remove [:svg.icon.icon-bin
                                              {:on-click (fn [op] (on-remove {:path path :value value :op op}))}

--- a/src/cljs/bluegenes/components/ui/list_dropdown.cljs
+++ b/src/cljs/bluegenes/components/ui/list_dropdown.cljs
@@ -43,14 +43,15 @@
   :restrict-type  (Optional) a keyword to restrict the list to a type, like :Gene
   :on-change      A function to call with the name of the list"
   (let [text-filter-atom (reagent/atom nil)]
-    (fn [& {:keys [value lists restrict-type on-change :as x]}]
+    (fn [& {:keys [value lists restrict-type on-change disabled :as x]}]
       (let [text-filter    (partial has-text? @text-filter-atom)
             type-filter    (partial has-type? restrict-type)
             filter-fn      (apply every-pred [text-filter type-filter])
             filtered-lists (filter filter-fn lists)]
         [:div.dropdown
          [:button.btn.btn-default.dropdown-toggle
-          {:style       {:text-transform "none"
+          {:disabled disabled
+           :style       {:text-transform "none"
                          :white-space    "normal"}
            :data-toggle "dropdown"}
           (str (or value "Choose a list") " ") [:span.caret]]

--- a/src/cljs/bluegenes/components/ui/results_preview.cljs
+++ b/src/cljs/bluegenes/components/ui/results_preview.cljs
@@ -34,9 +34,9 @@
           [:tr
            [:td {:col-span (count (:columnHeaders query-results))}
             [:h4 "Query returned no results"]]]
-          (doall (map
-                   (fn [r]
-                     ^{:key (reduce str (map :id r))} [table-row r])
+          (doall (map-indexed
+                   (fn [idx r]
+                     ^{:key idx} [table-row r])
                    (:results query-results))))
         (if (and (not hide-count?) (> (:iTotalRecords query-results) 5))
           [:tr

--- a/src/cljs/bluegenes/components/ui/results_preview.cljs
+++ b/src/cljs/bluegenes/components/ui/results_preview.cljs
@@ -26,7 +26,7 @@
        [:thead
         (into [:tr]
               (map (fn [h]
-                     ^{:key h} [table-header h])
+                     [table-header h])
                    (:columnHeaders query-results)))]
        [:tbody
         (if

--- a/src/cljs/bluegenes/routes.cljs
+++ b/src/cljs/bluegenes/routes.cljs
@@ -47,7 +47,16 @@
                        [:qb/make-tree]]))
 
   (defroute "/results" []
-            (dispatch [:set-active-panel :results-panel]))
+            (dispatch [:set-active-panel :results-panel]
+                      nil
+                      [:results/load-history 0]))
+
+  (defroute "/results/:idx" [idx]
+            (dispatch [:set-active-panel :results-panel
+                       nil
+                       ; URL PARAMETERS ARE ALWAYS STRINGS! Parse as Integer because
+                       ; we use the value as a location in a collection (nth [a b c d] "2")
+                       [:results/load-history (js/parseInt idx)]]))
 
   (defroute "/regions" []
             (dispatch [:set-active-panel :regions-panel]))

--- a/src/cljs/bluegenes/sections/mymine/events.cljs
+++ b/src/cljs/bluegenes/sections/mymine/events.cljs
@@ -666,7 +666,7 @@
   (fn [{db :db} [_ {:keys [type name title source]}]]
     (let [summary-fields (get-in db [:assets :summary-fields source (keyword type)])]
       {:db       db
-       :dispatch [:results/set-query
+       :dispatch [:results/history+
                   {:source source
                    :type   :query
                    :value  (build-list-query type summary-fields name title)}]

--- a/src/cljs/bluegenes/sections/querybuilder/events.cljs
+++ b/src/cljs/bluegenes/sections/querybuilder/events.cljs
@@ -275,11 +275,12 @@
   :qb/export-query
   (fn [{db :db} [_]]
     {:db db
-     :dispatch [:results/set-query
+     :dispatch [:results/history+
                 {:source (get-in db [:current-mine])
                  :type :query
-                 :value (get-in db [:qb :im-query])}]
-     :navigate (str "results")}))
+                 :value (assoc
+                          (get-in db [:qb :im-query])
+                          :title "Custom Built Query")}]}))
 
 (defn within? [col item]
   (some? (some #{item} col)))

--- a/src/cljs/bluegenes/sections/results/events.cljs
+++ b/src/cljs/bluegenes/sections/results/events.cljs
@@ -14,6 +14,22 @@
             [accountant.core :as accountant]
             [bluegenes.interceptors :refer [abort-spec]]))
 
+
+(comment
+  "To automatically display some results in this section (the Results / List Analysis page),
+  fire the :results/history+ event with a package that represents a query, like so:"
+  (dispatch [:results/history+ {:source :flymine
+                                :type :query
+                                :value {:title "Appears in Breadcrumb"
+                                        :from "Gene"
+                                        :select ["Gene.symbol"]
+                                        :where {:path "Gene.symbol" :op "=" :value "runt"}}}])
+  "
+  Doing so will automatically direct the browser to the /results/[latest-history-index] route
+  which in turn fires the [:results/load-history latest-history-index]. This triggers the fetching
+  of enrichment results and boots the im-table
+  ")
+
 (defn build-matches-query [query path-constraint identifier]
   (update-in (js->clj (.parse js/JSON query) :keywordize-keys true) [:where]
              conj {:path path-constraint
@@ -47,7 +63,6 @@
                                    :value identifier}]})]
       {:db (assoc-in db [:results :summary-chan] summary-chan)
        :get-summary-values summary-chan})))
-
 
 ; Fire this event to append a query package to the BlueGenes list analysis history
 ; and then route the browser to a URL that displays the last package in history (the one we just added)

--- a/src/cljs/bluegenes/sections/results/events.cljs
+++ b/src/cljs/bluegenes/sections/results/events.cljs
@@ -11,7 +11,6 @@
             [ajax.core :as ajax]
             [bluegenes.interceptors :refer [clear-tooltips]]
             [dommy.core :refer-macros [sel sel1]]
-    ;[bluegenes.sections.saveddata.events]
             [accountant.core :as accountant]
             [bluegenes.interceptors :refer [abort-spec]]))
 
@@ -34,96 +33,65 @@
 (reg-event-fx
   :results/get-item-details
   (fn [{db :db} [_ identifier path-constraint]]
-    (let [source         (get-in db [:results :package :source])
-          model          (get-in db [:mines source :service :model])
-          classname      (keyword (path/class model path-constraint))
+    (let [source (get-in db [:results :package :source])
+          model (get-in db [:mines source :service :model])
+          classname (keyword (path/class model path-constraint))
           summary-fields (get-in db [:assets :summary-fields source classname])
-          service        (get-in db [:mines source :service])
-          summary-chan   (fetch/rows
-                           service
-                           {:from classname
-                            :select summary-fields
-                            :where [{:path (last (clojure.string/split path-constraint "."))
-                                     :op "="
-                                     :value identifier}]})]
+          service (get-in db [:mines source :service])
+          summary-chan (fetch/rows
+                         service
+                         {:from classname
+                          :select summary-fields
+                          :where [{:path (last (clojure.string/split path-constraint "."))
+                                   :op "="
+                                   :value identifier}]})]
       {:db (assoc-in db [:results :summary-chan] summary-chan)
        :get-summary-values summary-chan})))
 
+
+; Fire this event to append a query package to the BlueGenes list analysis history
+; and then route the browser to a URL that displays the last package in history (the one we just added)
 (reg-event-fx
-  :results/set-query
+  :results/history+
   (abort-spec bluegenes.specs/im-package)
   (fn [{db :db} [_ {:keys [source value type] :as package}]]
-    (let [model (get-in db [:mines source :service :model])]
-      {:db (update-in db [:results] assoc
-                      :query value
-                      :package package
-                      :history [package]
-                      :history-index 0
-                      :query-parts (q/group-views-by-class model (get package :value))
-                      :enrichment-results nil)
-       ; TOOD ^:flush-dom
+    {:db (update-in db [:results :history] conj package)
+     ; By navigating to the URL below, the :results/load-index (directly below) event is fired;
+     :navigate (str "/results/" (count (get-in db [:results :history])))}))
+
+
+; Load one package at a particular index from the list analysis history collection
+(reg-event-fx
+  :results/load-history
+  [(clear-tooltips)] ; This clears any existing tooltips on the screen when the event fires
+  (fn [{db :db} [_ idx]]
+    (let [
+          ; Get the details of the current package
+          {:keys [source type value] :as package} (nth (get-in db [:results :history]) idx)
+          ; Get the current model
+          model (get-in db [:mines source :service :model])]
+      ; Store the values in app-db.
+      ; TODO - 99% of this can be factored out by passing the package to the :enrichment/enrich and parsing it there
+      {:db (update db :results assoc
+                   :query value
+                   :package package
+                   ; The index is used to highlight breadcrumbs
+                   :history-index idx
+                   :query-parts (q/group-views-by-class model value)
+                   ; Clear the enrichment results before loading any new ones
+                   :enrichment-results nil)
        :dispatch-n [
+                    ; Fire the enrichment event (see the TODO above)
                     [:enrichment/enrich]
+                    ; Boot the im-table
                     [:im-tables.main/replace-all-state
+                     ; The location in app-db in which im-tables will store its results
                      [:results :fortable]
+                     ; Default settings for the table
                      {:settings {:links {:vocab {:mine (name source)}
                                          :on-click (fn [val] (accountant/navigate! val))}}
                       :query value
                       :service (get-in db [:mines source :service])}]]})))
-
-
-(reg-event-fx
-  :results/add-to-history
-  [(clear-tooltips)]
-  (fn [{db :db} [_ {identifier :identifier} details]]
-    (let [last-source (:source (last (get-in db [:results :history])))
-          model       (get-in db [:mines last-source :service :model])
-          previous    (get-in db [:results :query])
-          query       (merge (build-matches-query
-                               (:pathQuery details)
-                               (:pathConstraint details)
-                               identifier)
-                             {:title (str
-                                       (:title details))})
-          new-package {:source last-source
-                       :type :query
-                       :value query}]
-      {:db (-> db
-               (update-in [:results :history] conj new-package)
-               (update-in [:results] assoc
-                          :query query
-                          :package new-package
-                          :history-index (inc (get-in db [:results :history-index]))
-                          :query-parts (q/group-views-by-class model query)
-                          :enrichment-results nil))
-       :dispatch-n [[:enrichment/enrich]
-                    [:im-tables.main/replace-all-state
-                     [:results :fortable]
-                     {:settings {:links {:vocab {:mine (name (:source (last (get-in db [:results :history]))))}
-                                         :on-click (fn [val] (accountant/navigate! val))}}
-                      :query query
-                      :service (get-in db [:mines last-source :service])}]]})))
-
-(reg-event-fx
-  :results/load-from-history
-  (fn [{db :db} [_ index]]
-    (let [package (get-in db [:results :history index])
-          model   (get-in db [:mines (:source package) :service :model])]
-      {:db (-> db
-               (update-in [:results] assoc
-                          :query (get package :value)
-                          :package package
-                          :history-index index
-                          :query-parts (q/group-views-by-class model (get package :value))
-                          :enrichment-results nil))
-       :dispatch-n [[:enrichment/enrich]
-                    [:im-tables.main/replace-all-state
-                     [:results :fortable]
-                     {:settings {:links {:vocab {:mine (name (:source (last (get-in db [:results :history]))))}
-                                         :on-click (fn [val] (accountant/navigate! val))}}
-                      :query (get package :value)
-                      :service (get-in db [:mines (:source package) :service])}]]})))
-
 
 (reg-event-fx
   :fetch-ids-from-query

--- a/src/cljs/bluegenes/sections/results/events.cljs
+++ b/src/cljs/bluegenes/sections/results/events.cljs
@@ -1,16 +1,11 @@
 (ns bluegenes.sections.results.events
   (:require-macros [cljs.core.async.macros :refer [go go-loop]])
   (:require [re-frame.core :refer [reg-event-db reg-event-fx reg-fx dispatch subscribe]]
-            [cljs.core.async :refer [put! chan <! >! timeout close!]]
+            [cljs.core.async :refer [put! chan <! close!]]
             [imcljs.fetch :as fetch]
             [imcljs.path :as path]
             [imcljs.query :as q]
-            [clojure.spec.alpha :as s]
-            [clojure.set :refer [intersection]]
-            [day8.re-frame.http-fx]
-            [ajax.core :as ajax]
             [bluegenes.interceptors :refer [clear-tooltips]]
-            [dommy.core :refer-macros [sel sel1]]
             [accountant.core :as accountant]
             [bluegenes.interceptors :refer [abort-spec]]))
 

--- a/src/cljs/bluegenes/sections/results/views.cljs
+++ b/src/cljs/bluegenes/sections/results/views.cljs
@@ -16,7 +16,7 @@
   (if (< length (count string)) (str (clojure.string/join (take (- length 3) string)) "...") string))
 
 (defn breadcrumb []
-  (let [history       (subscribe [:results/history])
+  (let [history (subscribe [:results/history])
         history-index (subscribe [:results/history-index])]
     (fn []
       [:div.breadcrumb-container
@@ -26,9 +26,9 @@
                (fn [idx {{title :title} :value}]
                  (let [adjusted-title (if (not= idx @history-index) (adjust-str-to-length 20 title) title)]
                    [:div {:class (if (= @history-index idx) "active")
-                         :on-click       (fn [x] (dispatch [:results/load-from-history idx]))}
+                          :on-click #(accountant/navigate! (str "/results/" idx))}
                     [tooltip
-                     { :title title}
+                     {:title title}
                      adjusted-title]])) @history))])))
 
 (defn no-results []
@@ -45,11 +45,11 @@
          [:div.results-and-enrichment
           [:div.col-md-8.col-sm-12.panel
            ;;[:results :fortable] is the key where the imtables data (appdb) are stored.
-             [tables/main [:results :fortable]]]
+           [tables/main [:results :fortable]]]
           [:div.col-md-4.col-sm-12
            [enrichment/enrich]
            ]]]
         ;;oh noes, somehow we made it here with noresults. Fail elegantly, not just console errors.
         [no-results]
         )
-)))
+      )))


### PR DESCRIPTION
## PR authors: @joshkh

### Do not merge, this is a work in progress :)

This PR is meant to address various bugs and missing features from Rachel's use case walkthrough.

### ID Resolver
- Lists saved from the ID Resolver now appear in the My Data section

### Templates
- Optional constraints on templates can now be toggled on or off

### List Analysis & Enrichment
- Ascii < > arrows on enrichment tables have been replaced with SVG icons
- Navigating through results on the List Analysis page now works with the browser's history. This was a decently sized update but in the end it actually simplifies the plumbing of the results page (see the top of `bluegenes.sections.results.views` for comments.
  - The `:results/set-query` and its various related events for managing the history have been replaced by just two events: `:results/history+` and `results/load-history`.
  - In order to work with the browser's back button, now the app simply has to direct to `/results/[idx]` which fires the events to fetch enrichment


## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [x] review a _minified_ build (e.g. `lein cljsbuild min once` + `lein run`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [x] ID resolver + results preview
- [x] Templates execute and show results
- [x] Templates allow you to select lists AND type in identifiers
- [x] Search (dropdown preview version)
- [x] Search (full results page)
- [x] Report page loads, including homologues and tools
- [x] Region search
- [ ] Login and logout works for more than one user (use test user demo@intermine.org pw demo if needed)

This is not an exhaustive list - if you spot something else strange please bring it up!
