### PR TITLE
added link to support chat in the footer and help page

### DIFF
--- a/src/cljs/bluegenes/components/enrichment/views.cljs
+++ b/src/cljs/bluegenes/components/enrichment/views.cljs
@@ -87,16 +87,13 @@
            [:span (if results (str " (" (count results) ")"))]
            (if (< 0 (count results))
              [:span
-              ;;TODO: replace the < below with the svg icon when enrichment is fixed.
-              ;;[:svg.icon.icon-circle-left [:use {:xlinkHref "#icon-circle-left"}]]
               [:span
                {:on-click (fn [] (swap! page-state update :page dec))
-                :title "View previous 5 enrichment results"} "<"]
-                ;;TODO: replace the > below with the svg icon when enrichment is fixed.
-                ;;[:svg.icon.icon-circle-right [:use {:xlinkHref "#icon-circle-right"}]]
+                :title "View previous 5 enrichment results"} [:svg.icon.icon-circle-left [:use {:xlinkHref "#icon-circle-left"}]]]
+
               [:span
                {:on-click (fn [] (swap! page-state update :page inc))
-                :title "View next 5 enrichment results"}">"]])]
+                :title "View next 5 enrichment results"}[:svg.icon.icon-circle-right [:use {:xlinkHref "#icon-circle-right"}]]]])]
           [:span [mini-loader "tiny"]])]
        (cond (seq (:results details)) enrichment-results-header)
        (into [:ul.enrichment-list]

--- a/src/cljs/bluegenes/sections/help/views.cljs
+++ b/src/cljs/bluegenes/sections/help/views.cljs
@@ -10,10 +10,11 @@
     [:div.approot.red
      [icons/icons]
      [:h1 "Help"]
-     [:p "bluegenes is a new InterMine interface that operates via InterMine's Web Services. It's actively under development, so there may be some interesting bugs - but feel free to have a look around, "[:a {:href "https://github.com/intermine/bluegenes/issues"} "suggest improvements, report bugs,"] " etc. " [:a {:href "http://intermine.readthedocs.io/en/latest/about/contact-us/"} "Contact us"] " if you'd like to discuss anything"]
+     [:p "Bluegenes is a new InterMine interface that operates via InterMine's Web Services. It's actively under development, so there may be some interesting bugs - but feel free to have a look around, "[:a {:href "https://github.com/intermine/bluegenes/issues"} "suggest improvements, report bugs,"] " etc. " [:a {:href "http://intermine.readthedocs.io/en/latest/about/contact-us/"} "Contact us"] " if you'd like to discuss anything"]
+     [:p [:a {:href "http://chat.intermine.org/"} [:svg.icon.icon-question [:use {:xlinkHref "#icon-question"}]]"Chat with us"]]
      [:h2 "Credits"]
      [:h3 "Design"]
      [:p "Icons are a mix of " [:a {:href "http://fontawesome.io/"} "fontawesome"]" and "[:a {:href "https://icomoon.io/"}"icomoon"] " free icons. We also use the "[:a {:href "http://fezvrasta.github.io/bootstrap-material-design/"} "bootstrap material design theme"] "."]
      [:h3 "Licence"]
-     [:p "bluegenes, like InterMine, is released under the "[:a {:href "https://tldrlegal.com/license/gnu-lesser-general-public-license-v2.1-(lgpl-2.1)"}"LGPL 2.1 licence"]"."]
+     [:p "Bluegenes, like InterMine, is released under the "[:a {:href "https://tldrlegal.com/license/gnu-lesser-general-public-license-v2.1-(lgpl-2.1)"}"LGPL 2.1 licence"]"."]
      ]))

--- a/src/cljs/bluegenes/views.cljs
+++ b/src/cljs/bluegenes/views.cljs
@@ -32,6 +32,7 @@
         [:img {:width "120px" :src "https://cdn.rawgit.com/intermine/design-materials/c4716412/logos/intermine/intermine.png" :alt "InterMine"}]]]
       [:a {:href "https://intermineorg.wordpress.com/cite/"} "Cite"]
       [:a {:href "http://intermine.readthedocs.io/en/latest/about/contact-us/"} "Contact"]
+       [:a {:href "http://chat.intermine.org/"} "Chat"]
       [:a {:href "https://intermineorg.wordpress.com/"} "Blog"]
        [:a {:on-click #(navigate! "/help")} [:svg.icon.icon-question [:use {:xlinkHref "#icon-question"}]] " Help"]]
      [:div [:p "Funded by:"]


### PR DESCRIPTION
@yochannah Fixes #215 : Added "Support Chat" link to Bluegenes' footer and Help page.
