### PR TITLE
MyMine context menus work again

### DIFF
--- a/src/cljs/bluegenes/sections/mymine/events.cljs
+++ b/src/cljs/bluegenes/sections/mymine/events.cljs
@@ -93,7 +93,7 @@
   ::new-folder
   (fn [db [_ location-trail name]]
     (let [action-target (not-empty (get-in db [:mymine :action-target]))
-          uuid          (keyword (str "tag-" (str (make-random-uuid))))]
+          uuid (keyword (str "tag-" (str (make-random-uuid))))]
       (if-not action-target
         (-> db (assoc-in [:mymine :tree uuid] {:label name :file-type :folder}))
         (-> db
@@ -174,6 +174,7 @@
 (reg-event-fx
   ::fetch-one-list
   (fn [{db :db} [_ trail {list-name :listName} parent-id]]
+    (js/console.log "fetching one list" list-name)
     (let [service (get-in db [:mines (get db :current-mine) :service])]
       {:im-chan {:chan (fetch/one-list service list-name)
                  :on-success [::fetch-one-list-success trail parent-id]
@@ -181,19 +182,20 @@
 
 (reg-event-fx
   ::copy-success
-  (fn [{db :db} [_ trail parent-id response]]
+  (fn [{db :db} [_ response]]
+    (js/console.log "copy success" response)
     {:dispatch-n [
                   [::clear-checked]
-                  [::fetch-one-list trail response parent-id]]}))
+                  [::fetch-one-list response]]}))
 
 (reg-event-fx
   ::copy-n
   (fn [{db :db}]
-    (let [ids           (get-in db [:mymine :checked])
-          lists         (get-in db [:assets :lists (get db :current-mine)])
+    (let [ids (get-in db [:mymine :checked])
+          lists (get-in db [:assets :lists (get db :current-mine)])
           names-to-copy (map :name (filter (comp ids :id) lists))
-          focus         (or (get-in db [:mymine :focus]) [:unsorted])
-          parent-id     (get-in db [:mymine :cursor :entry-id])]
+          focus (or (get-in db [:mymine :focus]) [:unsorted])
+          parent-id (get-in db [:mymine :cursor :entry-id])]
       ; Now automatically increment the names of the list (since we're copying many)
       (let [evts (reduce (fn [total next]
                            (if-let [previous (first (not-empty (filter #(s/starts-with? % (str next "_")) (map :name lists))))]
@@ -210,11 +212,11 @@
   ::copy-focus
   (fn [{db :db} [_ trail old-list-name new-list-name parent-id]]
     ;[on-success on-failure response-format chan params]
-    (let [service          (get-in db [:mines (get db :current-mine) :service])
-          target-file      (get-in db [:mymine :menu-file-details])
-          lists            (get-in db [:assets :lists (get db :current-mine)])
+    (let [service (get-in db [:mines (get db :current-mine) :service])
+          target-file (get-in db [:mymine :menu-file-details])
+          lists (get-in db [:assets :lists (get db :current-mine)])
           target-list-name (->> lists (filter (fn [l] (= (:id target-file) (:id l)))) first :name)
-          location         (butlast (:trail target-file))]
+          location (butlast (:trail target-file))]
       {:im-chan {:chan (save/im-list-copy service old-list-name new-list-name)
                  :on-success [::copy-success location parent-id]
                  :on-failure [::copy-failure]}})))
@@ -228,8 +230,8 @@
 (reg-event-fx
   ::delete-lists
   (fn [{db :db} [_]]
-    (let [lists          (get-in db [:assets :lists (get db :current-mine)])
-          checked        (get-in db [:mymine :checked])
+    (let [lists (get-in db [:assets :lists (get db :current-mine)])
+          checked (get-in db [:mymine :checked])
           selected-lists (map :name (filter (fn [l] (some #{(:id l)} checked)) lists))]
       (let [service (get-in db [:mines (get db :current-mine) :service])]
         {:im-chan {:chan (save/im-list-delete service selected-lists)
@@ -238,16 +240,10 @@
 
 (reg-event-fx
   ::copy
-  (fn [{db :db} [_ trail old-list-name new-list-name]]
-    ;[on-success on-failure response-format chan params]
-    (let [service          (get-in db [:mines (get db :current-mine) :service])
-          target-file      (get-in db [:mymine :menu-file-details])
-          lists            (get-in db [:assets :lists (get db :current-mine)])
-          target-list-name (->> lists (filter (fn [l] (= (:id target-file) (:id l)))) first :name)
-          location         (let [t (butlast (:trail target-file))]
-                             (if (= t '(:public)) nil t))]
+  (fn [{db :db} [_ old-list-name new-list-name]]
+    (let [service (get-in db [:mines (get db :current-mine) :service])]
       {:im-chan {:chan (save/im-list-copy service old-list-name new-list-name)
-                 :on-success [::copy-success location]
+                 :on-success [:assets/fetch-lists]
                  :on-failure [::copy-failure]}})))
 
 ;;;; END TODO
@@ -257,27 +253,20 @@
   (fn [{db :db} [_ trail response]]
     {:dispatch [:assets/fetch-lists trail response]}))
 
-
 (reg-event-fx
   ::rename-list
-  (fn [{db :db} [_ new-list-name]]
-    (let [service (get-in db [:mines (get db :current-mine) :service])
-          _       (js/console.log "DB" db)
-          id      (last (get-in db [:mymine :action-target]))
-          _       (js/console.log "ID" id)
-          {old-list-name :name} @(subscribe [::subs/one-list id])]
-      (js/console.log "RENAMING" old-list-name new-list-name)
+  (fn [{db :db} [_ old-list-name new-list-name]]
+    (let [service (get-in db [:mines (get db :current-mine) :service])]
       {:im-chan {:chan (save/im-list-rename service old-list-name new-list-name)
                  :on-success [:assets/fetch-lists]
                  :on-failure [::copy-failure]}})))
 
 (reg-event-fx
   ::delete
-  (fn [{db :db} [_ trail list-name]]
-    ;[on-success on-failure response-format chan params]
+  (fn [{db :db} [_ list-name]]
     (let [service (get-in db [:mines (get db :current-mine) :service])]
       {:im-chan {:chan (send/delete-list service list-name)
-                 :on-success [::delete-success trail]
+                 :on-success [:assets/fetch-lists]
                  :on-failure [::delete-failure]}})))
 
 (reg-event-db
@@ -299,11 +288,11 @@
   ::drop
   (fn [{db :db} [_ trail]]
     (let [{:keys [dragging dragging-over dragging-node]} (:mymine db)]
-      (let [tree               (get-in db [:mymine :tree])
+      (let [tree (get-in db [:mymine :tree])
             drop-parent-folder (parent-folder tree dragging-over)
-            drag-type          (:file-type (get-in tree dragging))
-            drop-type          (:file-type (get-in tree dragging-over))
-            dragging-id        (keyword (str (name (:file-type dragging-node)) "-" (:id dragging-node)))]
+            drag-type (:file-type (get-in tree dragging))
+            drop-type (:file-type (get-in tree dragging-over))
+            dragging-id (keyword (str (name (:file-type dragging-node)) "-" (:id dragging-node)))]
         ; Don't do anything if we're moving something into the same folder
         (cond
           (= dragging dragging-over) {:db db :dispatch [::drag-end]} ; File was moved onto itself. Ignore.
@@ -357,10 +346,10 @@
 (reg-event-fx
   ::lo-combine
   (fn [{db :db} [_ list-name]]
-    (let [lists          (get-in db [:assets :lists (get db :current-mine)])
-          checked        (get-in db [:mymine :checked])
+    (let [lists (get-in db [:assets :lists (get db :current-mine)])
+          checked (get-in db [:mymine :checked])
           selected-lists (map :name (filter (fn [l] (some #{(:id l)} checked)) lists))
-          parent-id      (get-in db [:mymine :cursor :entry-id])]
+          parent-id (get-in db [:mymine :cursor :entry-id])]
       (let [service (get-in db [:mines (get db :current-mine) :service])]
         {:im-chan {:chan (save/im-list-union service list-name selected-lists)
                    :on-success [::lo-success parent-id]
@@ -369,10 +358,10 @@
 (reg-event-fx
   ::lo-intersect
   (fn [{db :db} [_ list-name]]
-    (let [lists          (get-in db [:assets :lists (get db :current-mine)])
-          checked        (get-in db [:mymine :checked])
+    (let [lists (get-in db [:assets :lists (get db :current-mine)])
+          checked (get-in db [:mymine :checked])
           selected-lists (map :name (filter (fn [l] (some #{(:id l)} checked)) lists))
-          parent-id      (get-in db [:mymine :cursor :entry-id])]
+          parent-id (get-in db [:mymine :cursor :entry-id])]
       (let [service (get-in db [:mines (get db :current-mine) :service])]
         {:im-chan {:chan (save/im-list-intersect service list-name selected-lists)
                    :on-success [::lo-success parent-id]
@@ -381,10 +370,10 @@
 (reg-event-fx
   ::lo-difference
   (fn [{db :db} [_ list-name]]
-    (let [lists          (get-in db [:assets :lists (get db :current-mine)])
-          checked        (get-in db [:mymine :checked])
+    (let [lists (get-in db [:assets :lists (get db :current-mine)])
+          checked (get-in db [:mymine :checked])
           selected-lists (map :name (filter (fn [l] (some #{(:id l)} checked)) lists))
-          parent-id      (get-in db [:mymine :cursor :entry-id])]
+          parent-id (get-in db [:mymine :cursor :entry-id])]
       (let [service (get-in db [:mines (get db :current-mine) :service])]
         {:im-chan {:chan (save/im-list-difference service list-name selected-lists)
                    :on-success [::lo-success parent-id]
@@ -393,11 +382,11 @@
 (reg-event-fx
   ::lo-subtract
   (fn [{db :db} [_ list-name]]
-    (let [lists            (get-in db [:assets :lists (get db :current-mine)])
+    (let [lists (get-in db [:assets :lists (get db :current-mine)])
           [lists-a lists-b] (get-in db [:mymine :suggested-state])
           selected-lists-a (map :name lists-a)
           selected-lists-b (map :name lists-b)
-          parent-id        (get-in db [:mymine :cursor :entry-id])]
+          parent-id (get-in db [:mymine :cursor :entry-id])]
 
       (let [service (get-in db [:mines (get db :current-mine) :service])]
         {:im-chan {:chan (save/im-list-subtraction service list-name selected-lists-a selected-lists-b)
@@ -466,7 +455,7 @@
 (reg-event-fx ::store-tag []
               (fn [{db :db} [_ label]]
                 (let [context-menu-target (get-in db [:mymine :context-menu-target])
-                      mine-id             (get-in db [:current-mine])]
+                      mine-id (get-in db [:current-mine])]
                   {:db db
                    ::fx/http {:method :post
                               :transit-params {:im-obj-type "tag"
@@ -617,7 +606,7 @@
               (fn [{db :db} [_ tag]]
                 (let [{dragging-id :entry-id :as dragging} (get-in db [:mymine :drag :dragging])
                       {dropping-id :entry-id :as dropping} (get-in db [:mymine :drag :dragging-over])
-                      hierarchy    (get-in db [:mymine :hierarchy])
+                      hierarchy (get-in db [:mymine :hierarchy])
                       current-mine (get-in db [:current-mine])]
                   (let [noop {:db (assoc-in db [:mymine :drag] nil)}]
 
@@ -646,28 +635,28 @@
                                          (if (= entry-id (:entry-id e))
                                            (assoc e :parent-id parent-id)
                                            e)) (get-in db [:mymine :entries]))
-                      parent-tag  (first (filter (comp #{parent-id} :entry-id) new-entries))]
+                      parent-tag (first (filter (comp #{parent-id} :entry-id) new-entries))]
                   {:db (assoc-in db [:mymine :entries] new-entries)
                    :dispatch-n [[::rederive]
                                 [::set-cursor parent-tag]]})))
 
 
 (defn build-list-query [type summary-fields name title]
-  {:title  title
-   :from   type
+  {:title title
+   :from type
    :select summary-fields
-   :where  [{:path  type
-             :op    "IN"
-             :value name}]})
+   :where [{:path type
+            :op "IN"
+            :value name}]})
 
 
 (reg-event-fx
   ::view-list-results
   (fn [{db :db} [_ {:keys [type name title source]}]]
     (let [summary-fields (get-in db [:assets :summary-fields source (keyword type)])]
-      {:db       db
+      {:db db
        :dispatch [:results/history+
                   {:source source
-                   :type   :query
-                   :value  (build-list-query type summary-fields name title)}]
+                   :type :query
+                   :value (build-list-query type summary-fields name title)}]
        :navigate "/results"})))

--- a/src/cljs/bluegenes/sections/mymine/views/contextmenu.cljs
+++ b/src/cljs/bluegenes/sections/mymine/views/contextmenu.cljs
@@ -5,10 +5,8 @@
             [bluegenes.sections.mymine.subs :as subs]
             [oops.core :refer [ocall]]))
 
-(defmulti context-menu :im-obj-type)
-
-(defmethod context-menu "tag" []
-  (fn [{:keys [trail type]}]
+(defn tag-context-menu []
+  (fn [target]
     [:ul.dropdown-menu
      [:li {:data-toggle "modal"
            :data-keyboard true
@@ -24,7 +22,7 @@
            :data-target "#myMineDeleteFolderModal"}
       [:a "Remove"]]]))
 
-(defmethod context-menu "list" []
+(defn list-context-menu []
   (fn [target]
     [:ul.dropdown-menu
      [:li {:data-toggle "modal"
@@ -34,13 +32,13 @@
      [:li {:data-toggle "modal"
            :data-keyboard true
            :data-target "#myMineCopyModal"}
-      [:a "Copy"]]
+      [:a "Duplicate"]]
      [:li {:data-toggle "modal"
            :data-keyboard true
            :data-target "#myMineDeleteModal"}
       [:a "Delete"]]]))
 
-(defmethod context-menu :default []
+(defn default-context-menu []
   (fn [target]
     [:ul.dropdown-menu
      [:li [:a "Default"]]]))
@@ -48,6 +46,9 @@
 (defn context-menu-container []
   (let [context-menu-target (subscribe [::subs/context-menu-target])]
     (fn []
-      (let [{:keys [entry-id] :as item} @context-menu-target]
+      (let [{:keys [im-obj-type] :as target} @context-menu-target]
         [:div#contextMenu.dropdown.clearfix
-         ^{:key (str "context-menu" entry-id)} [context-menu item]]))))
+         (case im-obj-type
+           "tag" [tag-context-menu target]
+           "list" [list-context-menu target]
+           [default-context-menu])]))))

--- a/src/cljs/bluegenes/sections/mymine/views/modals.cljs
+++ b/src/cljs/bluegenes/sections/mymine/views/modals.cljs
@@ -71,8 +71,8 @@
     (r/create-class
       {:component-did-mount (fn [this] (reset! dom-node (js/$ (r/dom-node this))))
        :reagent-render (let [suggested-state (subscribe [::subs/suggested-modal-state])
-                             checked-items   (subscribe [::subs/checked-details])
-                             new-list-name   (r/atom nil)]
+                             checked-items (subscribe [::subs/checked-details])
+                             new-list-name (r/atom nil)]
                          (fn [{:keys [errors body on-success state]}]
                            [:div
                             [:h4 "Keep items from these lists"]
@@ -139,9 +139,9 @@
                                [:div.alert.alert-warning "A list with this name already exists"])]]))})))
 
 (defn modal-list-operations []
-  (let [state     (r/atom "")
+  (let [state (r/atom "")
         all-lists (subscribe [:lists/filtered-lists])
-        disabled  (r/atom false)]
+        disabled (r/atom false)]
     (r/create-class
       {:component-did-update (fn [])
        :component-did-mount (fn [this]
@@ -229,7 +229,7 @@
 (defn modal-delete-item []
   (let [input-dom-node (r/atom nil)
         modal-dom-node (r/atom nil)
-        dets           (subscribe [::subs/details])]
+        dets (subscribe [::subs/details])]
     (r/create-class
       {:component-did-mount (fn [this]
                               ; When modal is closed, clear the context menu target. This prevents the modal
@@ -240,7 +240,7 @@
                               #_(ocall (js/$ (r/dom-node this))
                                        :on "shown.bs.modal"
                                        (fn [] (ocall @input-dom-node :select))))
-       :reagent-render (fn [{:keys [file-type label trail]}]
+       :reagent-render (fn [{:keys [name]}]
                          [:div#myMineDeleteModal.modal.fade
                           {:tab-index "-1" ; Allows "escape" key to work.... for some reason
                            :role "dialog"
@@ -263,16 +263,16 @@
                               [:button.btn.btn-default
                                {:data-dismiss "modal"}
                                "Cancel"]
-                              [:button.btn.btn-success.btn-raised
+                              [:button.btn.btn-danger.btn-raised
                                {:data-dismiss "modal"
-                                :on-click (fn [] (dispatch [::evts/delete trail (:name @dets)]))}
-                               "Remove Folder"]]]]]])})))
+                                :on-click (fn [] (dispatch [::evts/delete name]))}
+                               "Delete List"]]]]]])})))
 
 
 (defn modal-new-folder []
   (let [input-dom-node (r/atom nil)
         modal-dom-node (r/atom nil)
-        menu-details   (subscribe [::subs/menu-details])]
+        menu-details (subscribe [::subs/menu-details])]
     (r/create-class
       {:component-did-mount (fn [this]
                               ; When modal is closed, clear the context menu target. This prevents the modal
@@ -318,8 +318,8 @@
 (defn modal-copy []
   (let [input-dom-node (r/atom nil)
         modal-dom-node (r/atom nil)
-        dets           (subscribe [::subs/details])
-        menu-details   (subscribe [::subs/menu-details])]
+        dets (subscribe [::subs/details])
+        menu-details (subscribe [::subs/menu-details])]
     (r/create-class
       {:component-did-mount (fn [this]
                               ; When modal is closed, clear the context menu target. This prevents the modal
@@ -330,7 +330,7 @@
                               (ocall (js/$ (r/dom-node this))
                                      :on "shown.bs.modal"
                                      (fn [] (ocall @input-dom-node :select))))
-       :reagent-render (fn [{:keys [file-type label trail]}]
+       :reagent-render (fn [{:keys [name description]}]
                          [:div#myMineCopyModal.modal.fade
                           {:tab-index "-1" ; Allows "escape" key to work.... for some reason
                            :role "dialog"
@@ -340,12 +340,13 @@
                             [:div.modal-header [:h2 "Copy List"]]
                             [:div.modal-body [:p "Please enter a name for the new list"]
                              [:input.form-control
-                              {:ref (fn [e] (when e (do (oset! e :value "") (reset! input-dom-node (js/$ e)))))
+                              {:ref (fn [e] (when e (do (oset! e :value name) (reset! input-dom-node (js/$ e)))))
                                :type "text"
                                :on-key-up (fn [evt]
                                             (case (oget evt :keyCode)
                                               13 (do ; Detect "Return
-                                                   (dispatch [::evts/copy trail (:name @dets) (ocall @input-dom-node :val)])
+                                                   ;(dispatch [::evts/copy trail (:name @dets) (ocall @input-dom-node :val)])
+
                                                    (ocall @modal-dom-node :modal "hide"))
                                               nil))}]]
                             [:div.modal-footer
@@ -355,14 +356,16 @@
                                "Cancel"]
                               [:button.btn.btn-success.btn-raised
                                {:data-dismiss "modal"
-                                :on-click (fn [] (dispatch [::evts/copy trail (:name @dets) (ocall @input-dom-node :val)]))}
+                                :on-click (fn []
+                                            (dispatch [::evts/copy name (ocall @input-dom-node :val)])
+                                            )}
                                "OK"]]]]]])})))
 
 
 (defn modal-lo []
   (let [input-dom-node (r/atom nil)
         modal-dom-node (r/atom nil)
-        dets           (subscribe [::subs/details])]
+        dets (subscribe [::subs/details])]
     (r/create-class
       {:component-did-mount (fn [this]
                               ; When modal is closed, clear the context menu target. This prevents the modal
@@ -404,7 +407,7 @@
 (defn modal-lo-intersect []
   (let [input-dom-node (r/atom nil)
         modal-dom-node (r/atom nil)
-        dets           (subscribe [::subs/details])]
+        dets (subscribe [::subs/details])]
     (r/create-class
       {:component-did-mount (fn [this]
                               ; When modal is closed, clear the context menu target. This prevents the modal
@@ -456,7 +459,7 @@
                               (ocall (js/$ (r/dom-node this))
                                      :on "shown.bs.modal"
                                      (fn [] (ocall @input-dom-node :select))))
-       :reagent-render (fn [{:keys [file-type label trail] :as it}]
+       :reagent-render (fn [{:keys [description name trail] :as dets}]
                          [:div#myMineRenameList.modal.fade
                           {:tab-index "-1" ; Allows "escape" key to work.... for some reason
                            :role "dialog"
@@ -466,7 +469,7 @@
                             [:div.modal-header [:h2 "Rename List"]]
                             [:div.modal-body [:p "Please enter a new name for your list"]
                              [:input.form-control
-                              {:ref (fn [e] (when e (do (oset! e :value label) (reset! input-dom-node (js/$ e)))))
+                              {:ref (fn [e] (when e (do (oset! e :value name) (reset! input-dom-node (js/$ e)))))
                                :type "text"
                                :on-key-up (fn [evt]
                                             (case (oget evt :keyCode)
@@ -481,7 +484,7 @@
                                "Cancel"]
                               [:button.btn.btn-success.btn-raised
                                {:data-dismiss "modal"
-                                :on-click (fn [] (dispatch-edit trail :label (ocall @input-dom-node :val)))}
+                                :on-click (fn [] (dispatch [::evts/rename-list name (ocall @input-dom-node :val)]))}
                                "OK"]]]]]])})))
 
 

--- a/src/cljs/bluegenes/sections/mymine/views/mymine.cljs
+++ b/src/cljs/bluegenes/sections/mymine/views/mymine.cljs
@@ -65,10 +65,8 @@
                           (dispatch [::evts/toggle-selected trail index {:reset? true}]))))
    :on-context-menu (fn [evt]
 
-                      (println "TRAIL IS" trail)
 
                       (when-not (oget evt :nativeEvent :ctrlKey)
-
 
                         (do
                           ; Prevent the browser from showing its context menu
@@ -590,7 +588,7 @@
         [:div.grid.grid-middle
          (merge {:class (when (= @context-menu-target file) "highlighted")}
                 (tag-drag-events file)
-                (trigger-context-menu file)
+                (trigger-context-menu (assoc dets :im-obj-type "list"))
                 {:on-click (fn []
                              (dispatch [::evts/set-context-menu-target file]))})
          [:div.col-1.shrink [checkbox im-obj-id]]


### PR DESCRIPTION
This includes _basic_ functionality:

Right clicking a list in MyMine exposes a context menu and modals to:

1. Rename
2. Duplicate
3. Delete

I haven't introduced any additional error checking or messages, so the user isn't yet prevented from doing things like renaming a list to one that already exists. That will be round two. :)

## PR authors: 
### Please describe your PR:

## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [x] review a _minified_ build (e.g. `lein cljsbuild min once` + `lein run`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [x] ID resolver + results preview
- [x] Templates execute and show results
- [x] Templates allow you to select lists AND type in identifiers
- [x] Search (dropdown preview version)
- [x] Search (full results page)
- [x] Report page loads, including homologues and tools
- [x] Region search
- [x] Login and logout works for more than one user (use test user demo@intermine.org pw demo if needed)

This is not an exhaustive list - if you spot something else strange please bring it up!
