### PR TITLE
Fix sticky template filter container

### DIFF
--- a/less/components/templates.less
+++ b/less/components/templates.less
@@ -21,7 +21,16 @@
     font-weight: bold;
 }
 
-.templates {
+
+.affix + .template-container {
+    padding-top: 102px;
+}
+
+
+.template-component-container {
+
+    width: 100%;
+
     .preview {
         max-width: 60vw;
         overflow-x: "hidden";
@@ -34,14 +43,22 @@
     .template-filters {
         background: darken(@body-background-color,3%);
         //this padding stops content showing through at weird breakpoints;
-        padding-top: @crazy-padding;
-        position: fixed;
+        // padding-top: @crazy-padding;
+        // position: fixed;
         z-index: 42; //a higher z-index than light tables is the answer. And 42 is always the answer.
-        margin-top: -@crazy-padding;
-        padding-bottom: 2px;
+        // margin-top: -@crazy-padding;
+        // padding-bottom: 2px;
         box-shadow: 1px 1px 1px rgba(0,0,0,0.2);
-        right: 0;
-        left: 0;
+        // right: 0;
+        // left: 0;
+        width: 100%;
+
+        &.affix {
+            top: 0;
+            width: 100%;
+        }
+
+
 
         .template-filter {
             .control-label {
@@ -329,7 +346,7 @@
                 :hover {
                     cursor: pointer;
                 }
-            } 
+            }
         }
     }
 
@@ -362,6 +379,7 @@
     }
 }
 
+/**
 @media (min-width:1200px) {
     .templates .template-filters {
         margin-top: -10px - @crazy-padding;
@@ -372,6 +390,7 @@
         margin-top: 1 4px;
     }
 }
+**/
 
 .constraint-container {
     input {

--- a/less/site.less
+++ b/less/site.less
@@ -56,7 +56,7 @@ html {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  margin: 0 1em;
+  margin: 0 0;
   flex-grow: 1;
 }
 @annoyingscrollbars: 5em;
@@ -74,7 +74,7 @@ main {
   display: flex;
   flex-grow: 1;
   justify-content: center;
-  margin-top: @spacer; //this margin directly offsets the annoying scrollbars that we were getting with a 100% page height and sticky header
+  // margin-top: @spacer; //this margin directly offsets the annoying scrollbars that we were getting with a 100% page height and sticky header
 }
 //smaller screens:
 @media (max-width:539px) {

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -117,7 +117,7 @@
         current-mine (subscribe [:current-mine])
         panel-is (fn [panel-key] (= @active-panel panel-key))]
     (fn []
-      [:nav.main-nav
+      [:nav#bluegenes-main-nav.main-nav
        [:ul
         [:li.minename.primary-nav {:on-click #(navigate! "/")}
          [active-mine-logo]

--- a/src/cljs/bluegenes/components/templates/views.cljs
+++ b/src/cljs/bluegenes/components/templates/views.cljs
@@ -8,7 +8,7 @@
             [imcljs.path :as im-path]
             [bluegenes.components.ui.constraint :refer [constraint]]
             [bluegenes.components.ui.results_preview :refer [preview-table]]
-            [oops.core :refer [oget]]
+            [oops.core :refer [oget ocall]]
             [clojure.string :as s]))
 
 
@@ -202,27 +202,34 @@
                      (dispatch [:template-chooser/set-text-filter (.. e -target -value)]))}])))
 
 
-(defn filters [categories template-filter filter-state]
-  [:div.template-filters.container-fluid
-   [:div.template-filter
-    [:label.control-label "Filter by category"]
-    [categories]]
-   [:div.template-filter
-    [:label.control-label "Filter by description"]
-    [template-filter filter-state]]])
+
+
+
+(defn filters []
+  (let [me (reagent/atom nil)]
+    (reagent/create-class
+      {:component-did-mount (fn []
+                              (let [nav-height (-> "#bluegenes-main-nav" js/$ (ocall :outerHeight true))]
+                                (some-> @me (ocall :affix (clj->js {:offset {:top nav-height}})))))
+       :reagent-render (fn [categories template-filter filter-state]
+                         [:div.template-filters.container-fluid
+                          {:ref (fn [e] (some->> e js/$ (reset! me)))}
+                          [:div.template-filter
+                           [:label.control-label "Filter by category"]
+                           [categories]]
+                          [:div.template-filter
+                           [:label.control-label "Filter by description"]
+                           [template-filter filter-state]]])})))
 
 
 (defn main []
   (let [im-templates (subscribe [:templates-by-category])
         filter-state (reagent/atom nil)]
     (fn []
-      [:div.container-fluid
-       ;(json-html/edn->hiccup @selected-template)
-       [:div.row
-        [:div.col-xs-12.templates
-         [filters categories template-filter filter-state]
-         [:div.template-list
-          ;;the bad placeholder exists to displace content, but is invisible. It's a duplicate of the filters header
-          [:div.bad-placeholder [filters categories template-filter filter-state]]
-          [templates @im-templates]]]
-        ]])))
+      [:div.template-component-container
+       [filters categories template-filter filter-state]
+       [:div.container.template-container
+        [:div.row
+         [:div.col-xs-12.templates
+          [:div.template-list
+           [templates @im-templates]]]]]])))


### PR DESCRIPTION
## PR authors: 
### Please describe your PR:

This branch fixes the atrocious abomination that is our sticky template filter container.

## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [x] review a _minified_ build (e.g. `lein cljsbuild min once` + `lein run`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [ ] ID resolver + results preview
- [x] Templates execute and show results
- [x] Templates allow you to select lists AND type in identifiers
- [x] Search (dropdown preview version)
- [x] Search (full results page)
- [x] Report page loads, including homologues and tools
- [x] Region search
- [ ] Login and logout works for more than one user (use test user demo@intermine.org pw demo if needed)

This is not an exhaustive list - if you spot something else strange please bring it up!
