### PR TITLE
Bump clj/cljs version, include highlight.js to support im-tables codegen

### DIFF
--- a/less/im-tables-overrides.less
+++ b/less/im-tables-overrides.less
@@ -1,9 +1,13 @@
 @import "overrides";
-@import "variables"; // well done, you've found the correct location to edit bluegenes specific
+@import "variables";
+// well done, you've found the correct location to edit bluegenes specific
 // imtables styles. Don't use im-tables.less, because it's a copy/paste from
 // the imtables repo.
 
+@lightish-grey: #ccc;
+
 .im-table {
+    .btn .fa {margin-right: @spacer/4}
     .btn-group {
         margin: 0;
 
@@ -25,7 +29,7 @@
         .table {
             margin-bottom: 0;
         }
-        border-bottom: solid 1px #ccc;
+        border-bottom: solid 1px  @lightish-grey;
         box-shadow: 1px 1px 1px 1px rgba(0,0,0,0.18);
     }
 
@@ -35,7 +39,7 @@
         }
 
         .imtable-constraint {
-            border: solid 1px #ccc;
+            border: solid 1px  @lightish-grey;
 
             .constraint-input {
                 margin: 0;
@@ -44,7 +48,7 @@
 
             select.form-control {
                 border: 0;
-                border-right: solid 1px #ccc;
+                border-right: solid 1px  @lightish-grey;
             }
 
             .btn,
@@ -54,7 +58,7 @@
             }
 
             .btn {
-                border-left: solid 1px #ccc;
+                border-left: solid 1px  @lightish-grey;
             }
 
             .btn,
@@ -66,6 +70,28 @@
         .btn {
             margin: 0;
         }
+    }
+    /* fix bootstrap silly negative margins */
+    .pagination-bar {
+        margin-left: 4px;
+    }
+
+    .dashboard-buttons > .btn-group {
+        border: solid 1px  @lightish-grey;
+        box-shadow: 1px 1px 1px rgba(0,0,0,0.2);
+        margin: 0.5em 0.25em;
+        border-radius: 2px;
+        min-height: 2.2em;
+        display: flex;
+        align-items: center;
+    }
+
+    .dashboard-buttons .dropdown-toggle {
+        min-height: 2em;
+    }
+
+    .im-table-toolbar label {
+      .dark-text;
     }
 }
 

--- a/less/im-tables.less
+++ b/less/im-tables.less
@@ -8,7 +8,6 @@
 /// You may, if need be, paste the new im-tables styles in here, but leave   ///
 /// this warning intact. Kthxbye.                                            ///
 ////////////////////////////////////////////////////////////////////////////////
-
 .table > thead > tr > th {
   vertical-align: top;
 }
@@ -100,6 +99,8 @@
 .im-modal .im-modal-content {
   flex: 0 0 auto;
   animation: slidein 150ms;
+  margin-left: 20px;
+  margin-right: 20px;
 }
 @keyframes fadein {
   from {
@@ -115,6 +116,21 @@
   }
   to {
     transform: translate(0%, 0%);
+  }
+}
+/*
+    This override is necessary to allow modals to expand to the width of their content rather
+    than be fixed to 600px as found in bootstrap. For example, code generation modal.
+*/
+.codegen-modal {
+  width: 100% !important;
+  padding-left: 30px;
+  padding-right: 30px;
+  max-width: 1200px !important;
+}
+@media (min-width: 768px) {
+  .codegen-modal .modal-dialog {
+    width: auto;
   }
 }
 /*
@@ -236,11 +252,20 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .im-table .hljs {
   white-space: pre;
 }
+.im-table .dashboard-buttons {
+  margin-right: 30px;
+}
+.im-table .codegen-checkbox-container {
+  margin-top: 15px;
+}
 .im-table .popover {
   padding: 0;
 }
 .im-table .popover .table {
   margin: 0;
+}
+.im-table .pagination-bar label {
+  line-height: 2.4em;
 }
 .im-table .inset {
   -webkit-box-shadow: inset 3px 3px 6px -4px rgba(0, 0, 0, 0.69);

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "homepage": "https://github.com/intermine/bluegenes#README",
   "dependencies": {
-    "bower": "^1.8.0"
+    "@cljs-oss/module-deps": "^1.1.1",
+    "bower": "^1.8.0",
+    "highlight.js": "^9.12.0"
   }
 }

--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,8 @@
 
 (defproject org.intermine/bluegenes (:version props)
   :dependencies [; Clojure
-                 [org.clojure/clojure "1.9.0-RC1"]
-                 [org.clojure/clojurescript "1.9.946"]
+                 [org.clojure/clojure "1.9.0"]
+                 [org.clojure/clojurescript "1.10.145"]
                  [org.clojure/core.async "0.3.443"]
 
                  ; MVC
@@ -131,6 +131,8 @@
                                         :asset-path "js/compiled"
                                         :source-map-timestamp true
                                         :pretty-print true
+                                        :npm-deps {:highlight.js "9.12.0"}
+                                        :install-deps true
                                         ;:parallel-build true
                                         :preloads [devtools.preload
                                                    re-frisk.preload]
@@ -143,6 +145,8 @@
                                         :output-to "resources/public/js/compiled/app.js"
                                         ;:output-dir "resources/public/js/compiled"
                                         :optimizations :advanced
+                                        :npm-deps {:highlight.js "9.12.0"}
+                                        :install-deps true
                                         :closure-defines {goog.DEBUG false}
                                         :pretty-print false}}
 

--- a/project.clj
+++ b/project.clj
@@ -76,8 +76,8 @@
 
 
                  ; Intermine Assets
-                 [org.intermine/im-tables "0.8.0"]
-                 [org.intermine/imcljs "0.4.0"]
+                 [org.intermine/im-tables "0.8.1"]
+                 [org.intermine/imcljs "0.5.1"]
                  [intermine/accountant-fragments "0.1.8"]]
 
   :deploy-repositories {"clojars" {:sign-releases false}}

--- a/project.clj
+++ b/project.clj
@@ -76,7 +76,7 @@
 
 
                  ; Intermine Assets
-                 [org.intermine/im-tables "0.7.0"]
+                 [org.intermine/im-tables "0.8.0"]
                  [org.intermine/imcljs "0.4.0"]
                  [intermine/accountant-fragments "0.1.8"]]
 

--- a/src/cljs/bluegenes/sections/reportpage/subs.cljs
+++ b/src/cljs/bluegenes/sections/reportpage/subs.cljs
@@ -37,10 +37,12 @@
              (->> current-templates
                   ; Only keep ones that meet the following criteria (return something other than nil)
                   (keep (fn [[template-kw {:keys [where tags] :as template-details}]]
+
                           ; When we only have one editable constraint
                           (when (= 1 (count (filter :editable where)))
                             ; Make a list of indices that are LOOKUP, editable, and
                             ; have a backing class of the report page item type
+
                             (when-let [replaceable-indexes
                                        (not-empty (keep-indexed (fn [idx {:keys [path op editable :as constraint]}]
                                                                   (when
@@ -49,18 +51,21 @@
                                                                       (= report-item-type (name (im-path/class current-model path)))
                                                                       (= editable true)) idx))
                                                                 where))]
+
                               ; When that list of indices is 1, aka we only have one constraint to change
                               (when (= 1 (count replaceable-indexes))
+
                                 ; Update that particular index with the report page item id and change the op to =
                                 ; and also update the path (which ends on a class) to include ".id" on the end.
                                 ; Don't make the assumption that it's <report-item-type>.id
                                 ; as a query's root might not be the same class as the object on the report page
                                 (let [constraint-path (get-in template-details [:where (first replaceable-indexes) :path])]
+
                                   [template-kw (update-in template-details [:where (first replaceable-indexes)] assoc
                                                           :value report-item-id
                                                           :path (str constraint-path ".id")
                                                           :op "=")]))))))
                   ; And return just the vals
-                  vals))))
+                  (map last)))))
 
 

--- a/src/cljs/bluegenes/sections/reportpage/views.cljs
+++ b/src/cljs/bluegenes/sections/reportpage/views.cljs
@@ -77,7 +77,7 @@
                                                                                 (:class vocab) "/"
                                                                                 (:objectId vocab)))}}}]))
                              @runnable-templates))
-                  (into [:div.container]
+                  (into [:div]
                         (map (fn [{:keys [name referencedType displayName] :as x}]
                                (let [key (str id name)]
                                  ^{:key key} [tbl {:loc [:report-page id name]


### PR DESCRIPTION
Tiny PR

* Bump CLJ and CLJS versions (better node js support)
* Add highlight.js to NodeJS dependencies

You shouldn't notice any differences between this branch and the dev branch except for maybe a node_modules directory appear in the project root when you build the app.

## PR authors: 
### Please describe your PR:

## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [x] review a _minified_ build (e.g. `lein cljsbuild min once` + `lein run`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [x] ID resolver + results preview
- [x] Templates execute and show results
- [x] Templates allow you to select lists AND type in identifiers
- [x] Search (dropdown preview version)
- [x] Search (full results page)
- [x] Report page loads, including homologues and tools
- [x] Region search
- [x] Login and logout works for more than one user (use test user demo@intermine.org pw demo if needed)

This is not an exhaustive list - if you spot something else strange please bring it up!
