### PR TITLE
Fix blank default mine

### DIFF
--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -83,7 +83,10 @@
                           [:li {:on-click (fn [e] (dispatch [:set-active-mine (keyword id)]))
                                 :class (cond (= id (:id @current-mine)) "active")}
                            [:a [mine-icon details]
-                            (:name details)]]) @(subscribe [:mines])))
+                            (if (= :default id)
+                                   (clojure.string/join " - " [(:name details) "Default"])
+                                   (:name details))
+                            ]]) @(subscribe [:mines])))
              [:li.special [:a {:on-click #(navigate! "/debug")} ">_ Developer"]])])))
 
 (defn logged-in []


### PR DESCRIPTION
## PR authors: 
### Please describe your PR:

Dropdown for mine selection (under the cog) no longer has a blank mine name. See #241 for a screenshot of before the fix.

## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [ ] review a _minified_ build (e.g. `lein cljsbuild min once` + `lein run`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [ ] ID resolver + results preview
- [ ] Templates execute and show results
- [ ] Templates allow you to select lists AND type in identifiers
- [ ] Search (dropdown preview version)
- [ ] Search (full results page)
- [ ] Report page loads, including homologues and tools
- [ ] Region search
- [ ] Login and logout works for more than one user (use test user demo@intermine.org pw demo if needed)

This is not an exhaustive list - if you spot something else strange please bring it up!
