### PR TITLE
ci: added Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+sudo: required
+
+before_script:
+  - wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -O /tmp/lein
+  - chmod +x /tmp/lein
+  - export PATH=$PATH:/tmp/lein
+
+script:
+  - npm install
+  - bower install
+  - lein less once
+  - lein cljsbuild once min


### PR DESCRIPTION
This PR add the configuration file for Travis CI.

Maintainers may want to go to https://travis-ci.com, log in with their account and activate the repo. Then, Travis will trigger a job for each commit pushed to the repo.