### PR TITLE
Shows command notification if CSS not compiled

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -473,3 +473,7 @@ button.btn {
   padding-right: 5px;
   padding-left: 5px;
 }
+
+#csscompiling {
+  display: none;
+}

--- a/src/clj/bluegenes/index.clj
+++ b/src/clj/bluegenes/index.clj
@@ -20,9 +20,14 @@
   [:style
    "#wrappy{display:flex;justify-content:center;align-items:center;height:90vh;width:100%;flex-direction:column;font-family:sans-serif;font-size:2em;color:#999}#loader{flex-grow:1;display:flex;align-items:center;justify-content:center}.loader-organism{width:40px;height:0;display:block;border:12px solid #eee;border-radius:20px;opacity:.75;margin-right:-24px;animation-timing-function:ease-in;position:relative;animation-duration:2.8s;animation-name:pulse;animation-iteration-count:infinite}.worm{animation-delay:.2s}.zebra{animation-delay:.4s}.human{animation-delay:.6s}.yeast{animation-delay:.8s}.rat{animation-delay:1s}.mouse{animation-delay:1.2s}.fly{animation-delay:1.4s}@keyframes pulse{0%,100%{border-color:#3f51b5}15%{border-color:#9c27b0}30%{border-color:#e91e63}45%{border-color:#ff5722}60%{border-color:#ffc107}75%{border-color:#8bc34a}90%{border-color:#00bcd4}}\n    "])
 
+(def css-compiling-style
+  [:style
+   "#csscompiling{position:fixed;bottom:0;right:0;padding:20px;height:100px;width:400px;background-color:#FFA726;}"])
+
 (defn head []
   [:head
    loader-style
+   css-compiling-style
    [:title "InterMine 2.0 BlueGenes"]
    (include-css
     "https://cdnjs.cloudflare.com/ajax/libs/gridlex/2.2.0/gridlex.min.css")
@@ -63,6 +68,14 @@
     [:div.mouse.loader-organism]
     [:div.fly.loader-organism]]])
 
+(defn css-compiler []
+  [:div#csscompiling
+
+   [:div.alert.alert-danger
+    [:h3 "Debug: Stylesheets not compiled"]
+    [:p "This page is missing its stylesheet. Please tell your administrator to run <b>'lein less once'</b>."]
+    [:div.clearfix]]])
+
 (defn index
   "Hiccup markup that generates the landing page and loads the necessary assets.
   A user might optionally have their identity already stored in a session."
@@ -72,6 +85,7 @@
     (html5
      (head)
      [:body
+      (css-compiler)
       (loader)
       [:div#app]
        ; Bust the cache by using the project's version number as a URL parameter


### PR DESCRIPTION
## PR authors: Vibhor Sehgal
### Please describe your PR:
Closes #276 

Displays a small alert to run CSS compilation commands if not done previously. After running the command compiled site.css file sets the property for the notification as `display: none;`. This way we can ensure this notification only appears in the dev mode and not production, as production will render compiled CSS files.

CSS not compiled View:
![image](https://user-images.githubusercontent.com/10993808/49430412-f629e880-f7d0-11e8-857b-e1c89f85e4c9.png)

CSS compiled View:
![image](https://user-images.githubusercontent.com/10993808/49430976-5ec59500-f7d2-11e8-985a-14791c04d921.png)


## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [x] review a _minified_ build (e.g. `lein prod`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [ ] ID resolver + results preview
- [ ] Templates execute and show results
- [ ] Templates allow you to select lists AND type in identifiers
- [ ] Search (dropdown preview version)
- [ ] Search (full results page)
- [ ] Report page loads, including homologues and tools
- [ ] Region search
- [ ] Login and logout works for more than one user (use test user demo@intermine.org pw demo if needed)

This is not an exhaustive list - if you spot something else strange please bring it up!
