### PR TITLE
Save the server! Fix for Region validation.

### DIFF
--- a/src/cljs/bluegenes/pages/regions/views.cljs
+++ b/src/cljs/bluegenes/pages/regions/views.cljs
@@ -137,6 +137,17 @@
      [:div.feature-tree-container
       {:class (if @results "shrinkified")} [feature-types-tree]]]))
 
+(defn matches-regex?
+  [v regex]
+  (boolean (re-matches regex v)))
+
+(defn is-valid?
+  [v]
+  (if (nil? v)
+    false
+    (let [regexp (clojure.string/join "--" (split v #"\n"))]
+      (matches-regex? regexp #"([A-Za-z0-9\.]+(:)[0-9]+((\.\.)|-)[0-9]+(--))*([A-Za-z0-9\.]+(:)[0-9]+((\.\.)|-)[0-9]+)"))))
+
 (defn input-section
   "Entire UI input section / top half of the region search"
   []
@@ -151,8 +162,10 @@
        {:disabled (or
                    (= "" @to-search)
                    (= nil @to-search)
+                   (not (is-valid? @to-search))
                    (empty? (filter (fn [[name enabled?]] enabled?) (:feature-types @settings))))
-        :on-click (fn [e] (dispatch [:regions/run-query])
+        :on-click (fn [e]
+                    (dispatch [:regions/run-query])
                     (ocall (oget e "target") "blur"))
         :title "Enter something into the 'Regions to search' box or click on [Show me an example], then click here! :)"}
        "Search"]]


### PR DESCRIPTION
## PR authors: Vibhor S.
### Please describe your PR:
Closes #23 
Disables the button if the user does not follow the syntax for the input. This might be a sweet temporary fix, can be improvised in the near future based on subsequent discussion/review.

## Reviewers: 
## Review checklist: 

 Before merging, confirm the following tasks have been executed

- [x] review a _minified_ build (e.g. `lein prod`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [ ] ID resolver + results preview
- [ ] Templates execute and show results
- [ ] Templates allow you to select lists AND type in identifiers
- [ ] Search (dropdown preview version)
- [ ] Search (full results page)
- [ ] Report page loads, including homologues and tools
- [ ] Region search
- [ ] Login and logout works for more than one user (use test user demo@intermine.org pw demo if needed)

This is not an exhaustive list - if you spot something else strange please bring it up!
