### PR TITLE
stop warning in console about overriding replace.

### DIFF
--- a/src/clj/bluegenes/mounts.clj
+++ b/src/clj/bluegenes/mounts.clj
@@ -4,7 +4,7 @@
             [config.core :refer [env]]
             [clojure.java.jdbc :as jdbc]
             [taoensso.timbre :as timbre :refer [infof]]
-            [clojure.string :refer [split replace]]
+            [clojure.string :as string :refer [split]]
             [clojure.set :refer [rename-keys]])
   (:import [java.net URI]))
 
@@ -15,7 +15,7 @@
     ; Parse the URL into parts parse-properties-uri is private, work around: reference by symbol!
     (let [{:keys [subname subprotocol user username password]} (#'jdbc/parse-properties-uri (URI. database-url))]
       ; Split the URL into [host:port dn-name]
-      (let [[host-and-port name] (-> subname (replace #"//" "") (split #"/"))]
+      (let [[host-and-port name] (-> subname (string/replace #"//" "") (split #"/"))]
         ; Parse a port (which might not be present
         (let [[host port] (split host-and-port #":")]
           {:db-subname subname


### PR DESCRIPTION
## PR authors: 
### Please describe your PR:

This change prevents thi error from coming up in the console when we run `lein run`

```bash
WARNING: replace already refers to: #'clojure.core/replace in namespace: bluegenes.mounts, being replaced by: #'clojure.string/replace
```

## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [ ] review a _minified_ build (e.g. `lein prod`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [ ] Upload page resolves IDs as expected
- [ ] Templates execute and show results
- [ ] Templates allow you to select lists AND type in identifiers
- [ ] Search (dropdown preview version)
- [ ] Search (full results page)
- [ ] Report page loads, including homologues and tools
- [ ] Region search
- [ ] Login and logout works for more than one user (use test user demo@intermine.org pw demo if needed)

This is not an exhaustive list - if you spot something else strange please bring it up!
