### PR TITLE
PhantomJS dep is only for development

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,7 +51,7 @@ lein clean
 lein doo phantom test once
 ```
 
-The above command assumes you will use [phantomjs](https://www.npmjs.com/package/phantomjs) (already declared as a Node.js dependency). However, please note that [doo](https://github.com/bensu/doo) can be configured to run cljs.test in many other JS environments (chrome, ie, safari, opera, slimer, node, rhino, or nashorn).
+The above command assumes you will use [phantomjs](https://www.npmjs.com/package/phantomjs) (already declared as a Node.js development dependency). However, please note that [doo](https://github.com/bensu/doo) can be configured to run cljs.test in many other JS environments (chrome, ie, safari, opera, slimer, node, rhino, or nashorn).
 
 ## What next?
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "@cljs-oss/module-deps": "^1.1.1",
     "bootstrap": "^3.3.7",
     "bootstrap-material-design": "https://github.com/intermine/bootstrap-material-design.git#im-0.0.2",
-    "highlight.js": "^9.12.0",
-    "phantomjs": "^2.1.7"
+    "highlight.js": "^9.12.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "phantomjs": "^2.1.7"
+  }
 }


### PR DESCRIPTION
## PR authors: 
### Please describe your PR:

PhantomJS dep is a _development_ dependency.

## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [ ] review a _minified_ build (e.g. `lein prod`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [ ] Upload page resolves IDs as expected
- [ ] Templates execute and show results
- [ ] Templates allow you to select lists AND type in identifiers
- [ ] Search (dropdown preview version)
- [ ] Search (full results page)
- [ ] Report page loads, including homologues and tools
- [ ] Region search
- [ ] Login and logout works for more than one user (use test user demo@intermine.org pw demo if needed)

This is not an exhaustive list - if you spot something else strange please bring it up!
