### PR TITLE
List upload improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: openjdk9
+jdk: openjdk11
 sudo: required
 
 # Install lein - required to build the project

--- a/src/cljs/bluegenes/components/idresolver/subs.cljs
+++ b/src/cljs/bluegenes/components/idresolver/subs.cljs
@@ -64,3 +64,11 @@
       :duplicates (count DUPLICATE)
       :converted (count TYPE_CONVERTED)
       :other (count OTHER)})))
+
+;;if the example doesn't exist, we don't want to show the "example"
+;; button to users. 
+(reg-sub
+ ::example?
+ (fn [db]
+   (let [current-mine (get db :current-mine)]
+     (some? (get-in db [:mines current-mine :idresolver-example])))))

--- a/src/cljs/bluegenes/components/idresolver/views.cljs
+++ b/src/cljs/bluegenes/components/idresolver/views.cljs
@@ -427,9 +427,15 @@
 
            [:div.btn-toolbar.pull-left]
            [:div.btn-toolbar.pull-right
-            [:button.btn.btn-default.btn-raised
-             {:on-click (fn [] (dispatch [::evts/load-example]))}
-             "Example"]
+            (let [example? (subscribe [::subs/example?])]
+              ;; if we don't have example text available, don't show the
+              ;; example button, but do log to the console that there's a problm
+              (if @example?
+                [:button.btn.btn-default.btn-raised
+                 {:on-click (fn [] (dispatch [::evts/load-example]))}
+                 "Example"]
+                (.debug js/console
+                        "No example button available due to missing or misconfigured example in the InterMine properties")))
             [:button.btn.btn-default.btn-raised
              {:on-click (fn [] (dispatch [::evts/reset]))}
              "Reset"]


### PR DESCRIPTION
## PR authors: 
### Please describe your PR:

Fixes #268 - no longer allow the example button to silently fail if the intermine server isn't configured with an example for the idresolver.

Quick note: Travis is failing installing the openjdk (which is something *it* is responsible for doing and not part of our scripts - but this passes on the gitlab build. I'm hoping Travis will fix itself. 

## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [x] review a _minified_ build (e.g. `lein prod`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [x] Upload page resolves IDs as expected
- [x] Templates execute and show results
- [x] Templates allow you to select lists AND type in identifiers
- [x] Search (dropdown preview version)
- [x] Search (full results page)
- [x] Report page loads, including homologues and tools
- [x] Region search
- [x] Login and logout works for more than one user (use test user demo@intermine.org pw demo if needed)

This is not an exhaustive list - if you spot something else strange please bring it up!

