### PR TITLE
Load InterMines from the registry

### DIFF
--- a/config/defaults/config.edn
+++ b/config/defaults/config.edn
@@ -1,3 +1,4 @@
 {
  ;;where tools are installed. Make sure this is an absolute path.
- :bluegenes-tool-path "/intermine/tools/node_modules"}
+ :bluegenes-tool-path "/intermine/tools/node_modules"
+}

--- a/less/components/navbar.less
+++ b/less/components/navbar.less
@@ -40,6 +40,10 @@
             }
             .transitions; //this is the mine chooser dropdown
             &.mine-settings {
+              img {
+                width:@spacer*1.5;
+                margin-right:@spacer;
+              }
                 .dropdown-menu {
                     padding: 0;
                     text-align: left;
@@ -49,7 +53,7 @@
                     height: 2.2* @spacer;
                     line-height: 1.2 * @spacer;
                     font-size: @spacer;
-                    padding: 0.6 * @spacer @spacer;
+                    padding: 0.6 * @spacer 0.8*@spacer;
                     box-sizing: border-box;
                 }
                 li,

--- a/less/developer.less
+++ b/less/developer.less
@@ -1,6 +1,7 @@
 @import "variables";
 
 .developer {
+  .panel {padding-bottom:@spacer;}
   .icon-size {
     margin: 1*@spacer 0;
   }

--- a/src/cljc/bluegenes/mines.cljc
+++ b/src/cljc/bluegenes/mines.cljc
@@ -1,26 +1,7 @@
 
 (ns bluegenes.mines)
 
-(def mines {:humanmine     {:id       :humanmine
-                            :name "HumanMine"
-                            :service {:root "www.humanmine.org/humanmine"
-                                      :token nil}}
-
-            :flymine       {:id :flymine
-                            :name "FlyMine"
-                            :service {:root "www.flymine.org/query"
-                                      :token nil}}
-
-            :humanmine-beta {:id      :humanmine-beta
-                             :name "HumanMine Beta"
-                             :service  {:root "beta.humanmine.org/beta"
-                                        :token nil}}
-
-            :flymine-beta   {:id         :flymine-beta
-                             :name "FlyMine Beta"
-                             :service    {:root "beta.flymine.org/beta"
-                                          :token nil}}
-            :default        {:id         :default
-                             :name "FlyMine Beta"
-                             :service    {:root "beta.flymine.org/beta"
+(def mines {:default        {:id         :default
+                             :name "FlyMine"
+                             :service    {:root "flymine.org/flymine"
                                           :token nil}}})

--- a/src/cljc/bluegenes/whitelist.cljc
+++ b/src/cljc/bluegenes/whitelist.cljc
@@ -1,3 +1,0 @@
-(ns bluegenes.whitelist)
-
-(def whitelist #{:Gene :Author :Protein :Organism :Publication :GOAnnotation :GOTerm :Homologue :Interaction :DataSet :genes :authors :proteins :organisms :publications :goAnnotation :goTerms :homologues :dataSets :interactions})

--- a/src/cljs/bluegenes/components/imcontrols/views.cljs
+++ b/src/cljs/bluegenes/components/imcontrols/views.cljs
@@ -42,7 +42,6 @@ Example usage:
                :disabled disabled
                :class class
                :on-change (fn [e]
-                            (.log js/console "%ce (oget e :target :value)" "border-bottom: solid gold 1px" e (oget e :target :value))
                             (on-change (oget e :target :value)))}]
              (concat
               [[:option {:value ""} "Any"]
@@ -57,24 +56,30 @@ Example usage:
   (let [model        (subscribe [:current-model])
         current-mine (subscribe [:current-mine])]
     (fn [{:keys [value on-change qualified?]}]
-      ; when qualified? is true, only show intermine object types that have class keys
+      ; when qualified? is true, only show intermine object types
+      ; that have class keys
       (let [{default-types :default-object-types
              class-keys :class-keys} @current-mine]
         [:div.form-group
          [:select.form-control
           {:value (or value (-> default-types first name))
            :on-change (fn [e] (on-change (oget e :target :value)))}
-          (into [:optgroup {:label "Popular"}]
-                (map (fn [[class-kw {:keys [name displayName]}]]
-                       [:option {:value name} displayName])
-                     (sort-classes (select-keys (:classes @model) default-types))))
-          (into [:optgroup {:label "All classes"}]
-                (map (fn [[class-kw {:keys [name displayName]}]]
-                       [:option {:value name} displayName])
-                     (sort-classes
-                      (apply dissoc
-                             (cond-> (:classes @model)
-                               qualified? (select-keys (keys class-keys))) default-types))))]]))))
+          (into
+           [:optgroup {:label "Popular"}]
+           (map
+            (fn [[class-kw {:keys [name displayName]}]]
+              [:option {:value name} displayName])
+            (sort-classes (select-keys (:classes @model) default-types))))
+          (into
+           [:optgroup {:label "All classes"}]
+           (map
+            (fn [[class-kw {:keys [name displayName]}]]
+              [:option {:value name} displayName])
+            (sort-classes
+             (apply dissoc
+                    (cond-> (:classes @model)
+                      qualified? (select-keys (keys class-keys)))
+                    default-types))))]]))))
 
 (defn object-type-dropdown []
   (let [display-names @(subscribe [:model])]
@@ -82,7 +87,10 @@ Example usage:
       [:div.btn-group.object-type-dropdown
        [:button.btn.btn-primary.dropdown-toggle
         {:data-toggle "dropdown"}
-        [:span (if selected-value (str (get-in display-names [selected-value :displayName]) " ") "Select a type") [:span.caret]]]
+        [:span (if selected-value
+                 (str (get-in display-names [selected-value :displayName])
+                      " ") "Select a type")
+         [:span.caret]]]
        (-> [:ul.dropdown-menu]
            (into (map (fn [value]
                         [:li [:a

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -25,8 +25,7 @@
   The dangerouslysetInnerHTML comment is intentional as a hidden iframe looks
   mega spooky to anyone inspecting source. Please don't remove the comment unless it's because we've got better auth working!!"
   [current-mine]
-  (let [link (str "//"
-                  (get-in @current-mine [:mine :url]) "/createAccount.do")]
+  (let [link (str (get-in @current-mine [:service :root]) "/createAccount.do")]
     [:div.register
      [:div.sneaky-iframe-fix-see-comment
       {:dangerouslySetInnerHTML {:__html (str "<!-- InterMine automatically redirects to the homepage unless you have a session (sigh) - but we want the user to go to the registration page. So we're loading the page in an iframe the user can't see, to bootstrap the session :/ -->")}}]

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -80,7 +80,7 @@
   "Output a single mine in the mine picker"
   [:li
    {:on-click (fn [e]
-                (dispatch [:set-active-mine (keyword (:id details))]))
+                (dispatch [:set-active-mine details]))
     :class (cond current-mine? "active")
     :title (:description details)}
    [:a (if current-mine?

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -73,22 +73,37 @@
            [mine-icon @current-mine]
            "Sign In"]]
          (when error?
-           [:div.alert.alert-danger.error-box "Invalid username or password"])]))))
+           [:div.alert.alert-danger.error-box
+            "Invalid username or password"])]))))
+
+(defn mine-entry [details current-mine?]
+  "Output a single mine in the mine picker"
+  [:li
+   {:on-click (fn [e]
+                (dispatch [:set-active-mine (keyword (:id details))]))
+    :class (cond current-mine? "active")
+    :title (:description details)}
+   [:a (if current-mine?
+         [mine-icon details]
+         [:img {:src (:logo (:images details))}])
+    (:name details)
+    (cond current-mine? " (current)")]])
 
 (defn settings []
+  "output the settings menu and mine picker"
   (let [current-mine (subscribe [:current-mine])]
     (fn []
       [:li.dropdown.mine-settings.secondary-nav
-       [:a.dropdown-toggle {:data-toggle "dropdown" :role "button"} [:svg.icon.icon-cog [:use {:xlinkHref "#icon-cog"}]]]
-       (conj (into [:ul.dropdown-menu]
-                   (map (fn [[id details]]
-                          [:li {:on-click (fn [e] (dispatch [:set-active-mine (keyword id)]))
-                                :class (cond (= id (:id @current-mine)) "active")}
-                           [:a [mine-icon details]
-                            (if (= :default id)
-                              (clojure.string/join " - " [(:name details) "Default"])
-                              (:name details))]]) @(subscribe [:mines])))
-             [:li.special [:a {:on-click #(navigate! "/debug/main")} ">_ Developer"]])])))
+       [:a.dropdown-toggle {:data-toggle "dropdown" :role "button"}
+        [:svg.icon.icon-cog [:use {:xlinkHref "#icon-cog"}]]]
+       (conj
+        (into
+         [:ul.dropdown-menu
+          [mine-entry @current-mine true]]
+         (map (fn [[id details]]
+                [mine-entry details false]) @(subscribe [:registry])))
+        [:li.special
+         [:a {:on-click #(navigate! "/debug/main")} ">_ Developer"]])])))
 
 (defn logged-in []
   (let [identity (subscribe [:bluegenes.subs.auth/identity])]

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -89,6 +89,13 @@
     (:name details)
     (cond current-mine? " (current)")]])
 
+(defn mine-entry-current [details]
+  "Output a single mine in the mine picker"
+  [:li
+   [:a [mine-icon details]
+    [:img {:src (:logo (:images details))}]
+    (:name details) " (current)"]])
+
 (defn settings []
   "output the settings menu and mine picker"
   (let [current-mine (subscribe [:current-mine])]
@@ -99,9 +106,9 @@
        (conj
         (into
          [:ul.dropdown-menu
-          [mine-entry @current-mine true]]
+          [mine-entry-current @current-mine]]
          (map (fn [[id details]]
-                [mine-entry details false]) @(subscribe [:registry])))
+                [mine-entry details]) @(subscribe [:registry])))
         [:li.special
          [:a {:on-click #(navigate! "/debug/main")} ">_ Developer"]])])))
 

--- a/src/cljs/bluegenes/db.cljc
+++ b/src/cljs/bluegenes/db.cljc
@@ -1,18 +1,12 @@
 (ns bluegenes.db)
 
 (def default-db
-  {:name "Intermine"
-   :mine-name :flymine
-   ;;events/boot.cljs auto-selects the first mine available if current-mine
+  {;;events/boot.cljs auto-selects the first mine available if current-mine
    ;;doesn't exist for any reason.
    :current-mine :flymine-beta
    :quicksearch-selected-index -1 ;;this defaults to select all in the quicksearch
-   :databrowser/whitelist #{:Gene :Author :Protein :Organism :Publication :GOAnnotation :GOTerm :Homologue :Interaction :DataSet :genes :authors :proteins :organisms :publications :goAnnotation :goTerms :homologues :dataSets :interactions}
-   :databrowser/root nil ;The default place to start in the data browser at /explore
-   :databrowser/node-locations {:Homologue {:x 120 :y 224 :radius 50} :Protein {:x 200 :y 300 :radius 17}}
    :results {:history []}
    :search {:selected-results #{}}
-
    :idresolver {:stage {:files nil
                         :textbox nil
                         :options {:case-sensitive false}
@@ -22,7 +16,6 @@
                              :identifiers []}
                 :save {:list-name nil}
                 :response nil}
-
    :mymine {:dragging nil
             :dragging-over nil
             :selected #{}
@@ -33,16 +26,6 @@
                       :type :alphanum
                       :asc? true}
             :tree {}
-            :tree-old {"test-folder" {:file-type :folder
-                                      :open true
-                                      :label "My Project"
-                                      :children {67000011 {:file-type :list
-                                                           :id 67000011}}}
-                       "another-folder" {:file-type :folder
-                                         :open true
-                                         :label "My Stuff"
-                                         :children {63000014 {:file-type :list
-                                                              :id 63000014}}}}
             :list-operations {:selected #{}}}
    :lists {:controls {:filters {:text-filter nil
                                 :flags {:authorized nil
@@ -52,4 +35,5 @@
    :qb {:root-class :Gene
         :order []
         :qm nil
+        ;;what is this??
         :mappy {"Gene" {"secondaryIdentifier" {}, "organism" {"name" {}}, "symbol" {}}}}})

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -62,16 +62,30 @@
 
 (reg-event-fx
  :set-active-mine
- (fn [{:keys [db]} [_ value keep-existing?]]
-   {:db (cond-> (assoc db :current-mine value)
-          (not keep-existing?) (assoc-in [:assets] {}))
-    :dispatch-n (list [:reboot] [:set-active-panel :home-panel])
-    :visual-navbar-minechange []}))
+ (fn [{:keys [db]} [_ new-mine keep-existing?]]
+   (let [new-mine-keyword (keyword (:namespace new-mine))
+         in-mine-list? (get-in db [:mines new-mine-keyword])]
+
+
+   {:db
+    (cond->
+     (assoc db :current-mine new-mine-keyword)
+      (not keep-existing?) (assoc-in [:assets] {})
+      (not in-mine-list?)
+     (assoc-in [:mines new-mine-keyword]
+               {:service {:root (:url new-mine)}
+                :name (:name new-mine)
+                :id new-mine-keyword}))
+    :dispatch-n (list
+                 [:reboot]
+                 [:set-active-panel :home-panel])
+    :visual-navbar-minechange []})))
 
 (reg-event-db
  :handle-suggestions
  (fn [db [_ results]]
-   (assoc db :suggestion-results (:results results))))
+   (assoc db :suggestion-results
+          (:results results))))
 
 (reg-event-fx
  :bounce-search
@@ -147,6 +161,7 @@
    (assoc-in db [:mines :flymine-beta :service :token] "faketoken")))
 
 (reg-event-db
+ ;; IS THIS USED?
  :messages/add
  (fn [db [_ {:keys [markup style]}]]
    (let [id (gensym)]

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -66,20 +66,19 @@
    (let [new-mine-keyword (keyword (:namespace new-mine))
          in-mine-list? (get-in db [:mines new-mine-keyword])]
 
-
-   {:db
-    (cond->
-     (assoc db :current-mine new-mine-keyword)
-      (not keep-existing?) (assoc-in [:assets] {})
-      (not in-mine-list?)
-     (assoc-in [:mines new-mine-keyword]
-               {:service {:root (:url new-mine)}
-                :name (:name new-mine)
-                :id new-mine-keyword}))
-    :dispatch-n (list
-                 [:reboot]
-                 [:set-active-panel :home-panel])
-    :visual-navbar-minechange []})))
+     {:db
+      (cond->
+       (assoc db :current-mine new-mine-keyword)
+        (not keep-existing?) (assoc-in [:assets] {})
+        (not in-mine-list?)
+        (assoc-in [:mines new-mine-keyword]
+                  {:service {:root (:url new-mine)}
+                   :name (:name new-mine)
+                   :id new-mine-keyword}))
+      :dispatch-n (list
+                   [:reboot]
+                   [:set-active-panel :home-panel])
+      :visual-navbar-minechange []})))
 
 (reg-event-db
  :handle-suggestions

--- a/src/cljs/bluegenes/events/registry.cljs
+++ b/src/cljs/bluegenes/events/registry.cljs
@@ -3,6 +3,12 @@
             [bluegenes.db :as db]
             [imcljs.fetch :as fetch]))
 
+;; this is not crazy to hardcode. The consequences of a mine that is lower than
+;; the minimum version using bluegenes could potentially result in corrupt lists
+;; so it *should* be hard to change.
+;;https://github.com/intermine/intermine/issues/1482
+(def min-intermine-version 27)
+
 (reg-event-fx
  ;; these are the intermines we'll allow users to switch to
  ::load-other-mines
@@ -21,6 +27,9 @@
          registry-mines-map
          (reduce
           (fn [new-map mine]
-            (assoc new-map (keyword (:namespace mine)) mine))
+            ;;only store a mine entry if the API version is high enough.
+            (if (>= (.parseInt js/window (:api_version mine) 10) min-intermine-version)
+              (assoc new-map (keyword (:namespace mine)) mine)
+              new-map))
           {} registry-mines)]
      (assoc-in db [:registry] registry-mines-map))))

--- a/src/cljs/bluegenes/events/registry.cljs
+++ b/src/cljs/bluegenes/events/registry.cljs
@@ -1,0 +1,26 @@
+(ns bluegenes.events.registry
+  (:require [re-frame.core :refer [reg-event-db reg-event-fx subscribe]]
+            [bluegenes.db :as db]
+            [imcljs.fetch :as fetch]))
+
+(reg-event-fx
+ ;; these are the intermines we'll allow users to switch to
+ ::load-other-mines
+ (fn [{db :db}]
+   {:im-chan
+    {:chan (fetch/registry false)
+     :on-success [::success-fetch-registry]}}))
+
+(reg-event-db
+ ::success-fetch-registry
+ (fn [db [_ mines]]
+   (let [registry-mines-response (js->clj mines :keywordize-keys true)
+         ;; extricate the mines from the deeply nested response object
+         registry-mines (get-in registry-mines-response [:body :instances])
+         ;;they *were* in an array, but a map would be easier to reference mines
+         registry-mines-map
+         (reduce
+          (fn [new-map mine]
+            (assoc new-map (keyword (:namespace mine)) mine))
+          {} registry-mines)]
+     (assoc-in db [:registry] registry-mines-map))))

--- a/src/cljs/bluegenes/pages/developer/devhome.cljs
+++ b/src/cljs/bluegenes/pages/developer/devhome.cljs
@@ -6,45 +6,63 @@
             [bluegenes.pages.developer.tools :as tools]
             [bluegenes.persistence :as persistence]
             [clojure.string :refer [blank?]]
-            [imcljs.internal.utils :as utils :refer [missing-http?-]]
             [accountant.core :refer [navigate!]]))
 
 (defn nav []
+  "Buttons to choose which mine you're using."
   [:ul.dev-navigation
    [:li [:a {:on-click #(navigate! "/debug/main")}
-         [:svg.icon.icon-cog [:use {:xlinkHref "#icon-cog"}]] "Debug Console"]]
+         [:svg.icon.icon-cog
+          [:use {:xlinkHref "#icon-cog"}]] "Debug Console"]]
    [:li
     [:a {:on-click #(navigate! "/debug/tool-store")}
-     [:svg.icon.icon-star-full [:use {:xlinkHref "#icon-star-full"}]] "Tool 'App Store'"]]
+     [:svg.icon.icon-star-full
+      [:use {:xlinkHref "#icon-star-full"}]] "Tool 'App Store'"]]
    [:li [:a {:on-click #(navigate! "/debug/icons")}
-         [:svg.icon.icon-intermine [:use {:xlinkHref "#icon-intermine"}]] "Icons"]]])
+         [:svg.icon.icon-intermine
+          [:use {:xlinkHref "#icon-intermine"}]] "Icons"]]])
 
 (defn mine-config []
-  (let [current-mine (subscribe [:current-mine])
-        mines (subscribe [:mines])
-        minelink (:root (:service @current-mine))
-        url (if missing-http?- (str "http://" minelink) minelink)]
+  "Outputs current intermine and list of mines from registry
+   To allow users to choose their preferred InterMine."
+  (let [current-mine (subscribe [:current-mine])]
     (fn []
       [:div.panel.container [:h3 "Current mine: "]
        [:p (:name @current-mine) " at "
-        [:a {:href url} url]]
+        [:span (:root (:service @current-mine))]]
        [:form
         [:legend "Select a new mine to draw data from:"]
-        (into [:div.form-group.mine-choice
-               {:on-change (fn [e]
-                             (dispatch [:set-active-mine (keyword (aget e "target" "value"))]))
-                :value     "select-one"}]
-              (map (fn [[id details]]
-                     (let [mine-name (if (blank? (:name details)) id (:name details))]
-                       [:label
-                        {:class (cond (= id (:id @current-mine)) "checked")}
-                        [:input
-                         {:type           "radio"
-                          :name           "urlradios"
-                          :id             id
-                          :defaultChecked (= id (:id @current-mine))
-                          :value          id}] mine-name])) @(subscribe [:mines])))        [:button.btn.btn-primary.btn-raised
-                                                                                            {:on-click (fn [e] (.preventDefault e))} "Save"]]])))
+        (into
+         [:div.form-group.mine-choice
+          [:label
+           {:class "checked"}
+           [:input
+            {:type           "radio"
+             :name           "urlradios"
+             :id             (:id @current-mine)
+             :defaultChecked true
+             :value          (:id @current-mine)}]
+           (:name @current-mine) " (current)"]]
+         (map
+          (fn [[id details]]
+            (cond
+              (not= id (:id @current-mine))
+              (let [mine-name
+                    (if (blank? (:name details))
+                      id (:name details))]
+                [:label {:title (:description details)}
+                 [:input
+                  {:on-change
+                   (fn [e]
+                     (dispatch
+                      [:set-active-mine details]))
+                   :type           "radio"
+                   :name           "urlradios"
+                   :id             id
+                   :value          id}] mine-name])))
+          @(subscribe [:registry])))
+        [:button.btn.btn-primary.btn-raised
+         {:on-click (fn [e] (.preventDefault e))} "Save"]]])))
 
 (defn version-number []
   [:div.panel.container
@@ -61,7 +79,8 @@
         (fn [e]
           (.preventDefault e)
           (persistence/destroy!)
-          (.reload js/document.location true))} "Delete bluegenes localstorage... for now."]]]))
+          (.reload js/document.location true))}
+       "Delete bluegenes localstorage... for now."]]]))
 
 (defn debug-panel []
   (fn []

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -14,6 +14,11 @@
  (fn [db]
    (:name db)))
 
+   (reg-sub
+    :registry
+    (fn [db]
+      (:registry db)))
+
 (reg-sub
  :short-name
  (fn [db]

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -14,10 +14,10 @@
  (fn [db]
    (:name db)))
 
-   (reg-sub
-    :registry
-    (fn [db]
-      (:registry db)))
+(reg-sub
+ :registry
+ (fn [db]
+   (:registry db)))
 
 (reg-sub
  :short-name
@@ -27,13 +27,13 @@
 (reg-sub
  :mine-url
  (fn [db]
-   (let [mine-name (:mine-name db)
+   (let [mine-name (:current-mine db)
          url       (:url (:mine (mine-name (:mines db))))]
      (str "http://" url))))
 
 (reg-sub :mine-default-organism
          (fn [db]
-           (let [mine-name (:mine-name db)
+           (let [mine-name (:current-mine db)
                  organism  (:abbrev (mine-name (:mines db)))]
              organism)))
 
@@ -44,7 +44,7 @@
 (reg-sub
  :mine-name
  (fn [db] 7
-   (:mine-name db)))
+   (:current-mine db)))
 
 (reg-sub
  :current-mine-name


### PR DESCRIPTION
## PR authors: 
### Please describe your PR:

This loads InterMines above API version 27 from the registry. 

## Reviewers:
### Review checklist: 

 Before merging, confirm the following tasks have been executed

- [x] review a _minified_ build (e.g. `lein prod`, _not_ `lein figwheel`). 

Checked the following pages load results successfully and allow you to proceed to the results or report page:

- [x] Upload page resolves IDs as expected
- [x] Templates execute and show results
- [x] Templates allow you to select lists AND type in identifiers
- [x] Search (dropdown preview version)
- [x] Search (full results page)
- [x] Report page loads, including homologues and tools
- [x] Region search
- [x] Login and logout works for more than one user (use test user demo@intermine.org pw demo if needed)

This is not an exhaustive list - if you spot something else strange please bring it up!
