### PR TITLE
Fix load-other-mines/fetch-registry not running

### DIFF
--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -58,7 +58,7 @@
                          ; Set a flag that all assets are fetched (unqueues URL routing)
                          [:finished-loading-assets]
                          ; use the registry to fetch other InterMines
-                         [::registry/load-other-mines]
+                         [:registry/fetch-registry]
                          ; Save the current state to local storage
                          [:save-state]]
             :halt? true}]})

--- a/src/cljs/bluegenes/events/registry.cljs
+++ b/src/cljs/bluegenes/events/registry.cljs
@@ -1,6 +1,5 @@
 (ns bluegenes.events.registry
   (:require [re-frame.core :refer [reg-event-db reg-event-fx subscribe]]
-            [bluegenes.db :as db]
             [imcljs.fetch :as fetch]))
 
 ;; this is not crazy to hardcode. The consequences of a mine that is lower than
@@ -11,14 +10,14 @@
 
 (reg-event-fx
  ;; these are the intermines we'll allow users to switch to
- ::load-other-mines
+ :registry/fetch-registry
  (fn [{db :db}]
-   {:im-chan
-    {:chan (fetch/registry false)
-     :on-success [::success-fetch-registry]}}))
+   {:db db
+    :im-chan {:chan (fetch/registry false)
+              :on-success [:registry/success-fetch-registry]}}))
 
 (reg-event-db
- ::success-fetch-registry
+ :registry/success-fetch-registry
  (fn [db [_ mines]]
    (let [registry-mines-response (js->clj mines :keywordize-keys true)
          ;; extricate the mines from the deeply nested response object


### PR DESCRIPTION
I noticed that `load-other-mines` was not running since the namespaced keywords were incorrect. I fixed these (in the same vein as the keywords used in *events/webproperties.cljs*) and also renamed it to `fetch-registry` so it would be consistent with the naming scheme of prefixing `success-` to the fetch keyword.