### PR TITLE
Allow symlinks when serving bluegenes-tool-path

### DIFF
--- a/src/clj/bluegenes/routes.clj
+++ b/src/clj/bluegenes/routes.clj
@@ -25,7 +25,7 @@
              ;; when running uberjar or clojar targets,
              ;; and make the jars about a million megabytes too big.
 
-  (files "/tools" {:root (:bluegenes-tool-path env)})
+  (files "/tools" {:root (:bluegenes-tool-path env), :allow-symlinks? true})
 
   (GET "/version" [] (response {:version "0.1.0"}))
 


### PR DESCRIPTION
Fixes #348. This was a bit tricky to test, until I realised the browser was reading from disk cache and switched to testing with curl instead. [=

Compojure's `files` route doesn't follow symlinks unless you add `:allow-symlinks? true` to the option map.
