### PR TITLE
Replace use of npm link in docs to use path instead as it's simpler

### DIFF
--- a/docs/tools/tool-api-tutorial.md
+++ b/docs/tools/tool-api-tutorial.md
@@ -311,5 +311,5 @@ Now, if you refresh your demo.html page, you should see the new css applied! You
 
 At this point, you should have a basic functional tool that consumes InterMine data and looks nice when you visit http://localhost:3456 - well done! So you'll probably want to test it in BlueGenes now, right? You have two ways to do this:
 
-- for tools under development, like this one, the easiest thing to do is [use npm link to install your new tool](tools.md#development-tools) in the bluegenes tool folder.  
-- for tools that are release ready (perhaps because you've tested them via the npm link method above), you can [release the tool on npm](https://docs.npmjs.com/cli/publish). This will make the tool available for others. To install a tool that's released via NPM, see our [installing published tools guide](tools.md#published-tools).
+- for tools under development, like this one, the easiest thing to do is [use npm to install your new tool from its path](tools.md#development-tools) in the bluegenes tool folder.
+- for tools that are release ready (perhaps because you've tested them via the method above), you can [release the tool on npm](https://docs.npmjs.com/cli/publish). This will make the tool available for others. To install a tool that's released via NPM, see our [installing published tools guide](tools.md#published-tools).

--- a/docs/tools/tools.md
+++ b/docs/tools/tools.md
@@ -37,28 +37,7 @@ If a tool's npm package is updated, all you need to do in order to pull the upda
 
 If your tool is under development, you'll need to mimic it living in the `tools/node_modules/@intermine` directory. Your tool should comply with the [tool API guidelines](tool-api.md).
 
-1. In the folder where **your tool** is being developed, type `npm link`. This tells npm on your system that you have a local node package at this location.
-2. In the bluegenes tool folder (which might be `bluegenes/tools`) type `npm link your-package-name` where your-package-name is the name defined for your package in its package.json. This creates a symbolic link to your package using [npm link](https://docs.npmjs.com/cli/link), so any updates you make in your package will automatically be mirrored in BlueGenes.
-3. BlueGenes looks in your package.json to figure out which tools to show. Open package.json in the tools folder, and tell it to look for the latest version of your package. That might look something like this: 
-
-```json
-{
-  "name": "tools",
-  "version": "1.0.0",
-  "description": "Tool API",
-  "dependencies": {
-    "my-awesome-new-tool-here": "latest", <---- Add a line that looks like this!!
-    "@intermine/bluegenes-cytoscape-interaction-network-viewer": "^1.1.0",
-    "@intermine/bluegenes-protvista": "^1.1.1"
-  },
-  "devDependencies": {},
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "Yo Yehudi",
-  "license": "ISC"
-}
-```
+You can do this by running `npm install --save /path/to/my/tool` inside the BlueGenes *tools* folder, putting in the appropriate path to the tool you're developing. This should create a symbolic link in the *node_modules* directory (nested under *@intermine*) to your package, and add it as a relative file path to *package.json*. Any changes you make to the tool in its own directory will automatically apply to BlueGenes (although you'll probably have to refresh your browser to load the new JS bundle).
 
 ## Creating new tools
 


### PR DESCRIPTION
As we discussed; npm installing a filesystem path is simpler since it's a single step process instead of two. [=