### PR TITLE
Cleanup old phantom, update docs and cypress

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -59,12 +59,15 @@ By default, the web server will be started on http://localhost:5000/. To change 
 
 ## Running tests
 
-    lein clean
-    lein doo phantom test once
+Make sure BlueGenes is running by using `lein dev` or `lein prod`. (Preferably make sure they pass in *prod*, but *dev* can be useful for stack traces.)
 
-The above command assumes you will use [phantomjs](https://www.npmjs.com/package/phantomjs) (already declared as a Node.js development dependency). However, please note that [doo](https://github.com/bensu/doo) can be configured to run cljs.test in many other JS environments (chrome, ie, safari, opera, slimer, node, rhino, or nashorn).
+Run all the Cypress tests:
 
+    npx cypress run
 
+Cypress also has a really useful interface for debugging failing tests:
+
+    DEBUG=cypress:* npx cypress open
 
 # Production Builds
 

--- a/package.json
+++ b/package.json
@@ -18,11 +18,10 @@
   "dependencies": {
     "@cljs-oss/module-deps": "^1.1.1",
     "bootstrap": "^3.3.7",
-    "bootstrap-material-design": "https://github.com/intermine/bootstrap-material-design.git#im-0.0.2",
+    "bootstrap-material-design": "git+https://github.com/intermine/bootstrap-material-design.git#im-0.0.2",
     "highlight.js": "^9.12.0"
   },
   "devDependencies": {
-    "cypress": "^3.1.4",
-    "phantomjs": "^2.1.7"
+    "cypress": "^3.4.0"
   }
 }

--- a/project.clj
+++ b/project.clj
@@ -160,14 +160,7 @@
                                         :npm-deps {:highlight.js "9.12.0"}
                                         :install-deps true
                                         :closure-defines {goog.DEBUG false}
-                                        :pretty-print false}}
-
-                       :test {:source-paths ["src/cljs" "test/cljs"]
-                              :compiler {:output-to "resources/public/js/test/test.js"
-                                         :output-dir "resources/public/js/test"
-                                         :main bluegenes.runner
-                                         :optimizations :none}}}}
-
+                                        :pretty-print false}}}}
 
   :main bluegenes.core
 

--- a/test/cljs/re_frame_boiler/core_test.cljs
+++ b/test/cljs/re_frame_boiler/core_test.cljs
@@ -1,7 +1,0 @@
-(ns re-frame-boiler.core-test
-  (:require [cljs.test :refer-macros [deftest testing is]]
-            [re-frame-boiler.core :as core]))
-
-(deftest fake-test
-  (testing "fake description"
-    (is (= 1 2))))

--- a/test/cljs/re_frame_boiler/runner.cljs
+++ b/test/cljs/re_frame_boiler/runner.cljs
@@ -1,5 +1,0 @@
-(ns re-frame-boiler.runner
-  (:require [doo.runner :refer-macros [doo-tests]]
-            [re-frame-boiler.core-test]))
-
-(doo-tests 're-frame-boiler.core-test)


### PR DESCRIPTION
I don't think PhantomJS for testing is used anymore?

I updated the docs for how to run the Cypress tests, and removed old references to the PhantomJS tests. I also updated the Cypress dependency to the latest version.