### PR TITLE
Fix various bugs when using BlueGenes paired with an InterMine instance

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -49,6 +49,7 @@
                  [inflections "0.13.2"]
                  [cljsjs/google-analytics "2015.04.13-0"]
                  [day8.re-frame/test "0.1.5"]
+                 [cljs-bean "1.4.0"]
 
                  ; Logging
                  [com.taoensso/timbre "4.10.0"]

--- a/src/clj/bluegenes/index.clj
+++ b/src/clj/bluegenes/index.clj
@@ -1,7 +1,7 @@
 (ns bluegenes.index
   (:require [hiccup.page :refer [include-js include-css html5]]
             [config.core :refer [env]]
-            [cheshire.core :as json]))
+            [cheshire.core :refer [generate-string]]))
 
 ;; Hello dear maker of the internet. You want to edit *this* file for prod,
 ;; NOT resources/public/index.html.
@@ -40,11 +40,11 @@
    [:meta {:content "width=device-width, initial-scale=1", :name "viewport"}]
    ;;outputting clj-based vars for use in the cljs:
    [:script
-    (str "var serverVars = {"
-         (when-let [s (:google-analytics env)]               (str "googleAnalytics: '" s "',"))
-         (when-let [s (:bluegenes-default-service-root env)] (str "serviceRoot: '" s "',"))
-         (when-let [s (:bluegenes-default-mine-name env)]    (str "mineName: '" s "',"))
-         "};")]
+    (str "var serverVars="
+         (generate-string {:googleAnalytics (:google-analytics env)
+                           :serviceRoot     (:bluegenes-default-service-root env)
+                           :mineName        (:bluegenes-default-mine-name env)})
+         ";")]
   ; Javascript:
    [:link {:rel "shortcut icon" :href "https://raw.githubusercontent.com/intermine/design-materials/f5f00be4/logos/intermine/fav32x32.png" :type "image/png"}]
    [:script {:src "http://cdn.intermine.org/js/intermine/imjs/3.15.0/im.min.js"}]

--- a/src/clj/bluegenes/index.clj
+++ b/src/clj/bluegenes/index.clj
@@ -40,13 +40,11 @@
    [:meta {:content "width=device-width, initial-scale=1", :name "viewport"}]
    ;;outputting clj-based vars for use in the cljs:
    [:script
-    "var serverVars={googleAnalytics :'" (:google-analytics env) "'"
-    (when (:bluegenes-default-service-root env)
-      (str ", intermineDefaults: {"
-           "serviceRoot:'"  (:bluegenes-default-service-root env) "',"
-           "mineName: '" (:bluegenes-default-mine-name env)  "'"
-           "}"))
-    "};"]
+    (str "var serverVars = {"
+         (when-let [s (:google-analytics env)]               (str "googleAnalytics: '" s "',"))
+         (when-let [s (:bluegenes-default-service-root env)] (str "serviceRoot: '" s "',"))
+         (when-let [s (:bluegenes-default-mine-name env)]    (str "mineName: '" s "',"))
+         "};")]
   ; Javascript:
    [:link {:rel "shortcut icon" :href "https://raw.githubusercontent.com/intermine/design-materials/f5f00be4/logos/intermine/fav32x32.png" :type "image/png"}]
    [:script {:src "http://cdn.intermine.org/js/intermine/imjs/3.15.0/im.min.js"}]

--- a/src/cljs/bluegenes/components/ui/alerts.cljs
+++ b/src/cljs/bluegenes/components/ui/alerts.cljs
@@ -18,24 +18,28 @@
 (defn message
   "A message component that dismisses itself after 5 seconds
   Messages should be in the following format:
-  {:markup [:div [:span somemarkup]]
-   :style success (or any bootstrap color name)
-   }"
+      {:markup [:span \"Your text\"]] ; Or any other markup.
+       :style \"success\" ; Or any bootstrap color name.
+       :timeout 0 ; Optional to override default auto-dismissal of 5 seconds.
+       }"
   []
   (r/create-class
-   {:component-did-mount (fn [this]
-                           (let [{:keys [id]} (r/props this)]
-                             (js/setTimeout
-                              (fn []
-                                (dispatch [:messages/remove id])) 5000)))
-    :reagent-render (fn [{:keys [markup style when id]}]
-                      [:div.alert.message
-                       {:class (str "alert-" (or style "info"))}
-                       [:span.markup markup]
-                       [:span.controls
-                        [:button.btn.btn-default.btn-xs.btn-raised
-                         {:on-click (fn [] (dispatch [:messages/remove id]))
-                          :style {:margin 0}} "X"]]])}))
+   {:component-did-mount
+    (fn [this]
+      (let [{:keys [id timeout] :or {timeout 5000}} (r/props this)]
+        (when (and timeout (pos? timeout))
+          (js/setTimeout
+           #(dispatch [:messages/remove id])
+           timeout))))
+    :reagent-render
+    (fn [{:keys [markup style id]}]
+      [:div.alert.message
+       {:class (str "alert-" (or style "info"))}
+       [:span.markup markup]
+       [:span.controls
+        [:button.btn.btn-default.btn-xs.btn-raised
+         {:on-click (fn [] (dispatch [:messages/remove id]))
+          :style {:margin 0}} "X"]]])}))
 
 (defn messages
   "Creates a message bar on the bottom of the screen"

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -203,15 +203,13 @@
    (assoc-in db [:mines (:current-mine db) :service :token] "faketoken")))
 
 (reg-event-db
- ;; IS THIS USED?
  :messages/add
- (fn [db [_ {:keys [markup style]}]]
-   (let [id (gensym)]
-     (assoc-in db [:messages id]
-               {:markup markup
-                :id id
-                :style style
-                :when (.getTime (js/Date.))}))))
+ (fn [db [_ props]]
+   (let [id (gensym)
+         msg (assoc props
+                    :id id
+                    :when (.getTime (js/Date.)))]
+     (assoc-in db [:messages id] msg))))
 
 (reg-event-db
  :messages/remove

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -5,7 +5,8 @@
             [imcljs.auth :as auth]
             [bluegenes.events.webproperties]
             [bluegenes.events.registry :as registry]
-            [bluegenes.route :as route]))
+            [bluegenes.route :as route]
+            [oops.core :refer [oget]]))
 
 (defn boot-flow
   "Produces a set of re-frame instructions that load all of InterMine's assets into BlueGenes
@@ -95,9 +96,9 @@
   default mine config.
   You can specify `:token my-token` if you want to reuse an existing token."
   [& {:keys [token]}]
-  (let [{:keys [serviceRoot mineName] :as serverVars}
-        (:intermineDefaults (js->clj js/serverVars :keywordize-keys true))]
-    (if (seq serverVars)
+  (let [serviceRoot (oget js/serverVars :serviceRoot)
+        mineName    (oget js/serverVars :mineName)]
+    (if serviceRoot
       {:id :default
        :name mineName
        :service {:root serviceRoot
@@ -207,8 +208,7 @@
 (reg-event-fx
  :start-analytics
  (fn [{db :db}]
-   (let [analytics-id (:googleAnalytics
-                       (js->clj js/serverVars :keywordize-keys true))
+   (let [analytics-id (oget js/serverVars :googleAnalytics)
          analytics-enabled? (not (clojure.string/blank? analytics-id))]
      (if analytics-enabled?
         ;;set tracker up if we have a tracking id

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -6,7 +6,7 @@
             [bluegenes.events.webproperties]
             [bluegenes.events.registry :as registry]
             [bluegenes.route :as route]
-            [oops.core :refer [oget]]))
+            [cljs-bean.core :refer [->clj]]))
 
 (defn boot-flow
   "Produces a set of re-frame instructions that load all of InterMine's assets into BlueGenes
@@ -96,8 +96,7 @@
   default mine config.
   You can specify `:token my-token` if you want to reuse an existing token."
   [& {:keys [token]}]
-  (let [serviceRoot (oget js/serverVars :?serviceRoot)
-        mineName    (oget js/serverVars :?mineName)]
+  (let [{:keys [serviceRoot mineName]} (->clj js/serverVars)]
     (if serviceRoot
       {:id :default
        :name mineName
@@ -208,7 +207,7 @@
 (reg-event-fx
  :start-analytics
  (fn [{db :db}]
-   (let [analytics-id (oget js/serverVars :?googleAnalytics)
+   (let [analytics-id (:googleAnalytics (->clj js/serverVars))
          analytics-enabled? (not (clojure.string/blank? analytics-id))]
      (if analytics-enabled?
         ;;set tracker up if we have a tracking id

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -96,8 +96,8 @@
   default mine config.
   You can specify `:token my-token` if you want to reuse an existing token."
   [& {:keys [token]}]
-  (let [serviceRoot (oget js/serverVars :serviceRoot)
-        mineName    (oget js/serverVars :mineName)]
+  (let [serviceRoot (oget js/serverVars :?serviceRoot)
+        mineName    (oget js/serverVars :?mineName)]
     (if serviceRoot
       {:id :default
        :name mineName
@@ -208,7 +208,7 @@
 (reg-event-fx
  :start-analytics
  (fn [{db :db}]
-   (let [analytics-id (oget js/serverVars :googleAnalytics)
+   (let [analytics-id (oget js/serverVars :?googleAnalytics)
          analytics-enabled? (not (clojure.string/blank? analytics-id))]
      (if analytics-enabled?
         ;;set tracker up if we have a tracking id

--- a/src/cljs/bluegenes/pages/templates/subs.cljs
+++ b/src/cljs/bluegenes/pages/templates/subs.cljs
@@ -15,14 +15,7 @@
 (reg-sub
  :templates
  (fn [db _]
-   (let [template-packages
-         (reduce
-          (fn [total [mine-kw templates]]
-            (doall (reduce
-                    (fn [t [name query]]
-                      (assoc t (keyword mine-kw name) query)) total templates)))
-          {} (seq (get-in db [:assets :templates])))]
-     template-packages)))
+   (get-in db [:assets :templates (:current-mine db)])))
 
 (reg-sub
  :template-chooser/count


### PR DESCRIPTION
- Fix reading serverVars containing InterMine instance data
- Do not show templates for both `:default` and any registry mines previously switched to
- Show informative message when no connection to InterMine instance