### PR TITLE
Dev helper feature - show token in dev page and scramble if needed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ out
 *.iml
 node_modules
 .lein-repl-history
+.rebel_readline_history
 .nrepl-port
 .DS_Store
 pom.xml

--- a/src/cljs/bluegenes/pages/developer/devhome.cljs
+++ b/src/cljs/bluegenes/pages/developer/devhome.cljs
@@ -88,21 +88,20 @@
 
 (defn scrambled-eggs-and-token []
   (let [token (subscribe [:active-token])]
-  (fn []
-    [:div.panel.container
-     [:h3 "Token"]
-     [:p "The current token for your current InterMine is:"]
-     [:pre @token]
-     [:p "Don't press the scramble token button unless you have been told to, or you're developing token-related code!"]
-     [:button.btn.btn-primary.btn-raised
-     {:type "button"
-      :on-click
-      (fn [e]
-        (.preventDefault e)
-        (.log js/console "%cscrambling dat token")
-        (dispatch [:scramble-tokens])
-        )}
-     "Scramble token"]])))
+    (fn []
+      [:div.panel.container
+       [:h3 "Token"]
+       [:p "The current token for your current InterMine is:"]
+       [:pre @token]
+       [:p "Don't press the scramble token button unless you have been told to, or you're developing token-related code!"]
+       [:button.btn.btn-primary.btn-raised
+        {:type "button"
+         :on-click
+         (fn [e]
+           (.preventDefault e)
+           (.log js/console "%cscrambling dat token")
+           (dispatch [:scramble-tokens]))}
+        "Scramble token"]])))
 
 (defn debug-panel []
   (fn []

--- a/src/cljs/bluegenes/pages/developer/devhome.cljs
+++ b/src/cljs/bluegenes/pages/developer/devhome.cljs
@@ -86,6 +86,24 @@
           (.reload js/document.location true))}
        "Delete bluegenes localstorage... for now."]]]))
 
+(defn scrambled-eggs-and-token []
+  (let [token (subscribe [:active-token])]
+  (fn []
+    [:div.panel.container
+     [:h3 "Token"]
+     [:p "The current token for your current InterMine is:"]
+     [:pre @token]
+     [:p "Don't press the scramble token button unless you have been told to, or you're developing token-related code!"]
+     [:button.btn.btn-primary.btn-raised
+     {:type "button"
+      :on-click
+      (fn [e]
+        (.preventDefault e)
+        (.log js/console "%cscrambling dat token")
+        (dispatch [:scramble-tokens])
+        )}
+     "Scramble token"]])))
+
 (defn debug-panel []
   (fn []
     (let [panel (subscribe [::subs/panel])]
@@ -97,6 +115,7 @@
           [:h1 "Debug console"]
           [mine-config]
           [localstorage-destroyer]
+          [scrambled-eggs-and-token]
           [version-number]]
          (= @panel "tool-store")
          [tools/tool-store]


### PR DESCRIPTION
Dev helper feature: shows which token is active in the dev window, and makes it easy to scramble a token if needed.