### PR TITLE
Improve project.clj (particularly lein aliases)

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,7 @@
+;; This namespace starts figwheel as part of the aliases:
+;;     lein dev
+;;     lein repl
+(ns user
+  (:require [figwheel-sidecar.repl-api :refer [start-figwheel!]]))
+
+(start-figwheel!)

--- a/docs/building.md
+++ b/docs/building.md
@@ -8,10 +8,22 @@
 * Latest supported [npm](https://www.npmjs.com/)
 * InterMine version 1.8+ (version 2.0 recommended)
 
-
 ## Download NPM dependencies
 
     npm install
+
+## Quickstart
+
+These commands are explained in more depth below, but if you know what you want here's a quick reference of the most useful ones.
+
+    lein dev         # start dev server with hot-reloading
+    lein repl        # start dev server with hot-reloading and nrepl
+    lein prod        # start prod server
+    lein deploy      # build prod release and deploy to clojars
+
+    lein format      # run cljfmt to fix code indentation
+    lein kaocha      # run unit tests
+    npx cypress run  # run cypress ui tests
 
 ## Running a dev environment
 
@@ -40,8 +52,10 @@ Note: even that you will not see a prompt telling you when it's complete, the br
 
 ### Make Leiningen reload code changes in the browser
 
+
     lein figwheel dev
 
+Note: if you use `lein run` or any alias calling it like `dev` or `repl`, Figwheel will be started automatically.
 
 ### Start the web server
 
@@ -91,9 +105,10 @@ Most of the time, we develop with uncompressed files - it's faster for hot reloa
 
 Sometimes the Closure compiler is overzealous and removes something we actually wanted to keep. To check what your work looks like in a minified build, run this in the terminal (I'd recommend closing any existing lein run / lein figwheel sessions first).
 
-    lein cljsbuild once min + lein run
+    lein with-profile prod cljsbuild once min
+    lein with-profile prod run
 
-There is also a shortcut:
+There is also a shortcut that in addition cleans and compiles CSS.
 
     lein prod
 
@@ -138,11 +153,9 @@ Official BlueGenes releases can be deployed to [Clojars](https://clojars.org/), 
 
 When deploying BlueGenes to Clojars, the JAR file should include all compiled assets: this includes JavaScript, less, and vendor libraries. This allows other projects to include BlueGenes as a dependency and deploy the client and server without needing to compile BlueGenes.
 
-To deploy a compiled JAR to clojars, include the `uberjar` profile when running the `lein deploy clojars` command:
+To deploy a compiled JAR to Clojars, simply use the `deploy` alias which automatically includes the `uberjar` profile and targets Clojars.
 
-    $ lein with-profile +uberjar deploy clojars
-
-
+    $ lein deploy
 
 # Troubleshooting
 

--- a/project.clj
+++ b/project.clj
@@ -83,17 +83,21 @@
   :cljfmt {:indents {wait-for [[:inner 0]]}}
 
   :aliases {"dev" ["do" "clean"
-                   ["less" "once"]
-                   ["trampoline" "run"]
-                   ["trampoline" "figwheel" "dev"]]
+                   ["pdo"
+                    ["less" "auto"]
+                    ["run"]]]
+            "repl" ["do" "clean"
+                    ["pdo"
+                     ["less" "auto"]
+                     ["repl"]]]
             "build" ["do" "clean"
                      ["less" "once"]
-                     ["cljsbuild" "once" "min"]]
+                     ["with-profile" "prod" "cljsbuild" "once" "min"]]
             "prod" ["do" "build"
                     ["with-profile" "prod" "run"]]
-            "deploy" ["with-profile" "+uberjar" "deploy"]
+            "deploy" ["with-profile" "+uberjar" "deploy" "clojars"]
             "format" ["cljfmt" "fix"]
-            "kaocha" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]}
+            "kaocha" ["with-profile" "kaocha" "run" "-m" "kaocha.runner"]}
 
   :min-lein-version "2.8.1"
 
@@ -112,7 +116,8 @@
   :less {:source-paths ["less"]
          :target-path "resources/public/css"}
 
-  :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
+  :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]
+                 :init (-main)}
 
   :profiles {:dev {:dependencies [[binaryage/devtools "0.9.10"]
                                   [day8.re-frame/re-frame-10x "0.4.2"]
@@ -120,10 +125,11 @@
                                   [cider/piggieback "0.4.1"]]
                    :resource-paths ["config/dev" "tools" "config/defaults"]
                    :plugins [[lein-figwheel "0.5.19"]
-                             [lein-doo "0.1.8"]]}
+                             [lein-doo "0.1.8"]]
+                   :source-paths ["dev"]}
              :kaocha {:dependencies [[lambdaisland/kaocha "0.0-541"]
                                      [lambdaisland/kaocha-cljs "0.0-59"]]}
-             :repl {:source-paths ["env/dev"]}
+             :repl {:source-paths ["dev"]}
              :prod {:resource-paths ["config/prod" "tools" "config/defaults"]}
              :uberjar {:resource-paths ["config/prod" "config/defaults"]
                        :prep-tasks ["build" "compile"]

--- a/project.clj
+++ b/project.clj
@@ -83,13 +83,14 @@
   :cljfmt {:indents {wait-for [[:inner 0]]}}
 
   :aliases {"dev" ["do" "clean"
-                   ["pdo" ["figwheel" "dev"]
-                    ["less" "auto"]
-                    ["run"]]]
+                   ["less" "once"]
+                   ["trampoline" "run"]
+                   ["trampoline" "figwheel" "dev"]]
             "build" ["do" "clean"
-                     ["cljsbuild" "once" "min"]
-                     ["less" "once"]]
-            "prod" ["do" "build" ["pdo" ["run"]]]
+                     ["less" "once"]
+                     ["cljsbuild" "once" "min"]]
+            "prod" ["do" "build"
+                    ["with-profile" "prod" "run"]]
             "deploy" ["with-profile" "+uberjar" "deploy"]
             "format" ["cljfmt" "fix"]
             "kaocha" ["with-profile" "+kaocha" "run" "-m" "kaocha.runner"]}
@@ -123,13 +124,11 @@
              :kaocha {:dependencies [[lambdaisland/kaocha "0.0-541"]
                                      [lambdaisland/kaocha-cljs "0.0-59"]]}
              :repl {:source-paths ["env/dev"]}
-             :prod {:dependencies []
-                    :resource-paths ["config/prod" "tools"  "config/defaults"]
-                    :plugins []}
+             :prod {:resource-paths ["config/prod" "tools" "config/defaults"]}
              :uberjar {:resource-paths ["config/prod" "config/defaults"]
-                       :prep-tasks ["clean" ["less" "once"] ["cljsbuild" "once" "min"] "compile"]
+                       :prep-tasks ["build" "compile"]
                        :aot :all}
-             :java9 {  :jvm-opts ["--add-modules" "java.xml.bind"]}}
+             :java9 {:jvm-opts ["--add-modules" "java.xml.bind"]}}
 
   :cljsbuild {:builds {:dev {:source-paths ["src/cljs"]
                              :figwheel {:on-jsload "bluegenes.core/mount-root"}


### PR DESCRIPTION
Resolves #406 and resolves #407.

This should make `lein dev` and `lein prod` (and all the other commands I listed on top of *building.md*) fairly robust.

Some things worth noting for future reference:
- `lein-pdo` doesn't work correctly with `less auto` and `figwheel dev` together, so I pushed the invocation of figwheel into `dev/user.clj`
- `lein run` actually starts a dev server (it includes `dev` profile by default)
- `cljsbuild once min` uses the `dev` profile by default, but it usually doesn't matter as it isn't involved with the dev vs. prod configs (the backend handles those)
    - except now that we have `dev/user.clj` starting figwheel, which means you need to use `lein with-profile prod cljsbuild once min` (although it shouldn't be necessary to invoke this by itself, without using the aliases)