### PR TITLE
Smoother UI when switching mines

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -17,7 +17,7 @@
 These commands are explained in more depth below, but if you know what you want here's a quick reference of the most useful ones.
 
     lein dev         # start dev server with hot-reloading
-    lein repl        # start dev server with hot-reloading and nrepl
+    lein repl        # start dev server with hot-reloading and nrepl (no clean or css)
     lein prod        # start prod server
     lein deploy      # build prod release and deploy to clojars
 

--- a/project.clj
+++ b/project.clj
@@ -86,10 +86,6 @@
                    ["pdo"
                     ["less" "auto"]
                     ["run"]]]
-            "repl" ["do" "clean"
-                    ["pdo"
-                     ["less" "auto"]
-                     ["repl"]]]
             "build" ["do" "clean"
                      ["less" "once"]
                      ["with-profile" "prod" "cljsbuild" "once" "min"]]

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -89,6 +89,7 @@
    (let [mine-kw         (keyword mine)
          different-mine? (not= mine-kw (:current-mine db))
          done-booting?   (not (:fetching-assets? db))
+         not-home?       (not= (:active-panel db) :home-panel)
          in-registry?    (contains? (:registry db) mine-kw)
          in-mines?       (contains? (:mines db) mine-kw)
          mine-m          (get-in db [:registry mine-kw])]
@@ -102,6 +103,9 @@
                                          {:service {:root (:url mine-m)}
                                           :name (:name mine-m)
                                           :id mine-kw})
+         not-home?     (update :db assoc
+                               :active-panel :home-panel
+                               :panel-params nil)
          ;; We need to make sure to :reboot when switching mines.
          done-booting? (-> (assoc-in [:db :fetching-assets?] true)
                            (assoc :dispatch [:reboot])))


### PR DESCRIPTION
Fixes choppy UI when switching mines. See #415 and commit body text for details.

I decided to drop the idea of having the *Loading Intermine* screen appear, as switching mines is pretty fast and it would be more annoying to have the screen appear for only a half second.

This PR can be tested by having any page other than home open, (*My Data* is pretty noticeable) then switch to a different mine with the mine switcher.
