### PR TITLE
Dynamic page titles

### DIFF
--- a/src/cljs/bluegenes/components/search/events.cljs
+++ b/src/cljs/bluegenes/components/search/events.cljs
@@ -2,7 +2,8 @@
   (:require [re-frame.core :refer [dispatch reg-event-db reg-event-fx]]
             [imcljs.fetch :as fetch]
             [oops.core :refer [oget]]
-            [goog.functions :refer [rateLimit]]))
+            [goog.functions :refer [rateLimit]]
+            [bluegenes.effects :refer [document-title]]))
 
 (def results-batch-size
   "The amount of results we should fetch at a time."
@@ -135,6 +136,7 @@
 
 (reg-event-fx
  :search/full-search
+ [document-title]
  (fn [{db :db} [_ search-term removed-filter?]]
    (let [filters         (get-in db [:search-results :active-filters])
          connection      (get-in db [:mines (get db :current-mine) :service])

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -16,7 +16,7 @@
             [bluegenes.components.search.events :as search-full]
             [bluegenes.pages.reportpage.events]
             [bluegenes.pages.querybuilder.events]
-            [bluegenes.effects]
+            [bluegenes.effects :refer [document-title]]
             [bluegenes.route :as route]
             [imcljs.fetch :as fetch]
             [imcljs.path :as im-path]
@@ -28,6 +28,7 @@
 ; Change the main panel to a new view
 (reg-event-fx
  :do-active-panel
+ [document-title]
  (fn [{db :db} [_ active-panel panel-params evt]]
    (cond-> {:db (assoc db
                        :active-panel active-panel
@@ -85,6 +86,7 @@
 ;;   registry, and makes sure to reboot when mine is switched after booting.
 (reg-event-fx
  :set-current-mine
+ [document-title]
  (fn [{db :db} [_ mine]]
    (let [mine-kw         (keyword mine)
          different-mine? (not= mine-kw (:current-mine db))

--- a/src/cljs/bluegenes/pages/reportpage/events.cljs
+++ b/src/cljs/bluegenes/pages/reportpage/events.cljs
@@ -1,10 +1,12 @@
 (ns bluegenes.pages.reportpage.events
-  (:require [re-frame.core :as re-frame :refer [reg-event-db reg-event-fx reg-fx dispatch subscribe]]
+  (:require [re-frame.core :as re-frame :refer [reg-event-db reg-event-fx]]
             [imcljs.fetch :as fetch]
-            [bluegenes.components.tools.events :as tools]))
+            [bluegenes.components.tools.events :as tools]
+            [bluegenes.effects :refer [document-title]]))
 
 (reg-event-db
  :handle-report-summary
+ [document-title]
  (fn [db [_ summary]]
    (-> db
        (assoc-in [:report :summary] summary)

--- a/src/cljs/bluegenes/titles.cljs
+++ b/src/cljs/bluegenes/titles.cljs
@@ -1,0 +1,47 @@
+(ns bluegenes.titles
+  (:require [clojure.string :as string]
+            [bluegenes.pages.reportpage.components.summary :as summary]))
+
+(def document-titles
+  "Define document title templates for each corresponding panel keyword.
+  This should be a map with panel keyword keys and vector values. The vector
+  will be joined and should consist of db pointers (explained below)."
+  (let [App    "InterMine BlueGenes"
+        Mine   #(get-in % [:mines (:current-mine %) :name])
+        Type   [:report :summary :rootClass]
+        Name   #(summary/choose-title-column (get-in % [:report :summary]))
+        Debug  [:debug-panel]
+        Search [:search-results :keyword]
+        Query  [:results :history-index]]
+    {:home-panel         ["Home"             Mine App]
+     :debug-panel        [Debug "Debug"      Mine App]
+     :templates-panel    ["Templates"        Mine App]
+     :reportpage-panel   [Name Type "Report" Mine App]
+     :upload-panel       ["Upload"           Mine App]
+     :search-panel       [Search "Search"    Mine App]
+     :results-panel      [Query "Results"    Mine App]
+     :regions-panel      ["Region Search"    Mine App]
+     :mymine-panel       ["MyMine"           Mine App]
+     :help-panel         ["Help"             Mine App]
+     :querybuilder-panel ["Query Builder"    Mine App]}))
+
+(defn *db->str
+  "Converts a db pointer to its value, usually a string.
+  A db pointer can be one of the following types:
+      function - called with db as argument
+      vector   - called as third argument to `(get-in db)`
+      string   - passed through"
+  [db *db]
+  (condp (fn [test-fn value] (test-fn value)) *db
+    fn?     (*db db)
+    vector? (get-in db *db)
+    *db))
+
+(defn db->title
+  "Takes an app-db as argument and returns the corresponding title."
+  [db]
+  (->> (:active-panel db)
+       document-titles
+       (map (partial *db->str db))
+       (filter some?)
+       (string/join " - ")))


### PR DESCRIPTION
Update `document.title` based on the content displayed/page open in the app.

Can be tested by navigating around the app and seeing that the title displayed in the web browser tab changes. Note that there's a bug where switching mines while at the home page won't update the tab title; this will get fixed when #417 is merged in.
