### PR TITLE
Support running bluegenes in https

### DIFF
--- a/src/clj/bluegenes/index.clj
+++ b/src/clj/bluegenes/index.clj
@@ -30,7 +30,7 @@
    css-compiling-style
    [:title "InterMine 2.0 BlueGenes"]
    (include-css "https://cdnjs.cloudflare.com/ajax/libs/gridlex/2.2.0/gridlex.min.css")
-   (include-css "http://cdn.intermine.org/js/intermine/im-tables/2.0.0/main.sandboxed.css")
+   (include-css "https://cdn.intermine.org/js/intermine/im-tables/2.0.0/main.sandboxed.css")
    (include-css "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css")
    (include-css "/css/site.css")
    (include-css "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css")
@@ -47,7 +47,7 @@
          ";")]
   ; Javascript:
    [:link {:rel "shortcut icon" :href "https://raw.githubusercontent.com/intermine/design-materials/f5f00be4/logos/intermine/fav32x32.png" :type "image/png"}]
-   [:script {:src "http://cdn.intermine.org/js/intermine/imjs/3.15.0/im.min.js"}]
+   [:script {:src "https://cdn.intermine.org/js/intermine/imjs/3.15.0/im.min.js"}]
    [:script {:crossorigin "anonymous"
              :integrity "sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="
              :src "https://code.jquery.com/jquery-3.1.0.min.js"}]

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -104,7 +104,7 @@
                  :token token}}
       {:id :default
        :name nil
-       :service {:root "http://www.flymine.org/flymine"
+       :service {:root "https://www.flymine.org/flymine"
                  :token token}})))
 
 (defn wait-for-registry?

--- a/src/cljs/bluegenes/events/registry.cljs
+++ b/src/cljs/bluegenes/events/registry.cljs
@@ -1,6 +1,7 @@
 (ns bluegenes.events.registry
   (:require [re-frame.core :refer [reg-event-db reg-event-fx]]
-            [imcljs.fetch :as fetch]))
+            [imcljs.fetch :as fetch]
+            [clojure.string :as string]))
 
 ;; this is not crazy to hardcode. The consequences of a mine that is lower than
 ;; the minimum version using bluegenes could potentially result in corrupt lists
@@ -16,12 +17,23 @@
     {:chan (fetch/registry false)
      :on-success [::success-fetch-registry]}}))
 
+(def protocol (delay (.. js/window -location -protocol)))
+
+(defn compatible-protocol?
+  "If the active protocol is secure, it will return false for insecure URLs.
+  If the active protocol is insecure, it will return true for all URLs."
+  [url]
+  (if (= @protocol "https:")
+    (not (string/starts-with? url "http:"))
+    true))
+
 (reg-event-fx
  ::success-fetch-registry
  (fn [{db :db} [_ mines]]
    (let [;; they *were* in an array, but a map would be easier to reference mines
          registry (into {} (comp (filter #(>= (js/parseInt (:api_version %) 10)
                                               min-intermine-version))
+                                 (filter #(compatible-protocol? (:url %)))
                                  (map (juxt (comp keyword :namespace) identity)))
                         mines)
          current-mine (:current-mine db)


### PR DESCRIPTION
This PR fixes resources not loading due to using http, and filters away insecure http mines when https is active. Fixes #412.

Needs to be used with https://github.com/intermine/imcljs/pull/38. Can be tested by setting up nginx as a HTTPS reverse proxy (any tutorial on the net is applicable). You should see that non-https mines like LocustMine are not present in the mine switcher when bluegenes is run with https.