### PR TITLE
Error handling in upload page/ID resolver

### DIFF
--- a/src/cljs/bluegenes/components/idresolver/subs.cljs
+++ b/src/cljs/bluegenes/components/idresolver/subs.cljs
@@ -49,6 +49,21 @@
          (fn [db]
            (get-in db [:idresolver :stage :view])))
 
+(reg-sub ::parsing?
+         (fn [db]
+           (= (get-in db [:idresolver :stage :status :action]) :parsing)))
+
+(reg-sub ::parsed?
+         (fn [db]
+           (boolean (get-in db [:idresolver :stage :flags :parsed]))))
+
+(reg-sub
+ ::in-progress?
+ :<- [::parsing?]
+ :<- [::parsed?]
+ (fn [[parsing? parsed?]]
+   (or parsing? parsed?)))
+
 (reg-sub
  ::stats
  :<- [::resolution-response]

--- a/src/cljs/bluegenes/components/idresolver/views.cljs
+++ b/src/cljs/bluegenes/components/idresolver/views.cljs
@@ -687,13 +687,16 @@
 
 (defn review-step []
   (let [resolution-response (subscribe [::subs/resolution-response])
+        in-progress? (subscribe [::subs/in-progress?])
         list-name (subscribe [::subs/list-name])
         stats (subscribe [::subs/stats])
         tab (subscribe [::subs/review-tab])]
     (fn []
       (let [{:keys [matches issues notFound converted duplicates all other]} @stats]
         (if (= nil @resolution-response)
-          [:div [loader]]
+          (if @in-progress?
+            [:div [loader]]
+            (dispatch [::route/navigate ::route/upload-step {:step "input"}]))
           [:div
            [:div.flex-progressbar
             [:div.title
@@ -843,8 +846,7 @@
       [:div.wizard
        [breadcrumbs (:step @panel-params)]
        [:div.wizard-body
-        (case
-         (:step @panel-params)
+        (case (:step @panel-params)
           :save [review-step]
           [upload-step])]])))
 


### PR DESCRIPTION
Improve handling HTTP error codes in im-chan effect and redirect to */upload/input* from */upload/save* when no ID resolution in progress (this can happen if you go to the URL directly, or after refreshing an expired token).

Resolves #399 and resolves #300. Dependent on https://github.com/intermine/imcljs/pull/39. Can be tested by running `bluegenes.events.scrambleTokens()` in JS console, then continuing with the example in the upload page.