### PR TITLE
Pass summary-fields to im-tables-3 to save extra requests

### DIFF
--- a/src/cljs/bluegenes/pages/reportpage/views.cljs
+++ b/src/cljs/bluegenes/pages/reportpage/views.cljs
@@ -39,7 +39,8 @@
           (map (fn [{:keys [name referencedType displayName] :as x}]
                  ^{:key (str id (:name x))}
                  [tbl {:loc [:report-page id (:name x)]
-                       :service (:service @service)
+                       :service (merge (:service @service)
+                                       {:summary-fields @summary-fields})
                        :title displayName
                        :query {:from object-type
                                :select (map (partial str object-type "." (:name x) ".") (map strip-class (get @summary-fields (keyword referencedType))))
@@ -56,12 +57,14 @@
                @nonempty-collections-references))))
 
 (defn templates-for-entity [service current-mine-name id]
-  (let [runnable-templates (subscribe [::subs/runnable-templates])]
+  (let [runnable-templates (subscribe [::subs/runnable-templates])
+        summary-fields     (subscribe [:current-summary-fields])]
     (into [:div]
           (map (fn [{:keys [name title] :as t}]
                  (let [key nil]
                    [tbl {:loc [:report-page id (:name t)]
-                         :service (:service @service)
+                         :service (merge (:service @service)
+                                         {:summary-fields @summary-fields})
                          :title title
                          :query t
                          :settings {:pagination {:limit 5}

--- a/src/cljs/bluegenes/pages/results/events.cljs
+++ b/src/cljs/bluegenes/pages/results/events.cljs
@@ -86,9 +86,9 @@
    (let [; Get the details of the current package
          {:keys [source type value] :as package} (get-in db [:results :queries title])
           ; Get the current model
-         model (get-in db [:mines source :service :model])
-         mine-name (get-in db [:mines source])
-         service (get-in db [:mines source :service])]
+         model          (get-in db [:mines source :service :model])
+         service        (get-in db [:mines source :service])
+         summary-fields (get-in db [:assets :summary-fields source])]
      (if (nil? package)
        ;; The query result doesn't exist. Fail gracefully!
        (do
@@ -112,7 +112,7 @@
                      [:enrichment/enrich]
                      [:im-tables/load
                       [:results :table]
-                      {:service service
+                      {:service (merge service {:summary-fields summary-fields})
                        :query value
                        :settings {:pagination {:limit 10}
                                   :links {:vocab {:mine (name source)}


### PR DESCRIPTION
Each instance of im-tables-3 has to fetch *summary-fields*, but if we pass it to the table instances, they won't have to do this. This saves one HTTP request per table, which amounts to a lot on the report page where there are close to a hundred im-tables.

This PR can be tested by opening the network panel in your browser's dev tools and observing that a fresh load of a page with one or more im-tables only causes the `summaryfields` endpoint to be requested once (which is when Bluegenes boots).