### PR TITLE
Fix Roboto font not loading in HTTPS

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -24,7 +24,7 @@
 @import "im-tables-overrides";
 @import "datatype-colors";
 @import "components/icons";
-@import url(https:fonts.googleapis.com/css?family=Roboto:400,700,300);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,700,300);
 
 body {
   background: @body-background-color;


### PR DESCRIPTION
The Google font Roboto was not loading when Bluegenes is run with HTTPS, due to a malformed URL.

You can test this PR by seeing that the text look like normal when Bluegenes is run with HTTPS.