### PR TITLE
remove re-frisk import

### DIFF
--- a/src/cljs/bluegenes/core.cljs
+++ b/src/cljs/bluegenes/core.cljs
@@ -1,7 +1,6 @@
 (ns bluegenes.core
   (:require [reagent.core :as reagent]
             [re-frame.core :as re-frame]
-            [re-frisk.core :refer [enable-re-frisk!]]
             [bluegenes.utils]
             [im-tables.core]
             [bluegenes.events]
@@ -22,7 +21,6 @@
 ;(defn dev-setup []
 ;  (when config/debug?
 ;    (devtools/install!)
-;    (enable-re-frisk!)
 ;    (println "dev mode")))
 
 (defn mount-root []


### PR DESCRIPTION
re-frisk import can cause compilation errors since it's not in project.clj any longer and was only provided by other libraries (i.e. imcljs and im-tables-3). 
