### PR TITLE
Use fingerprint compiler option for cache busting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,4 @@
-(def props {:version "0.9.11"})
-
-(defproject org.intermine/bluegenes (:version props)
+(defproject org.intermine/bluegenes "0.9.11"
   :licence "LGPL-2.1-only"
   :description "Bluegenes is a Clojure-powered user interface for InterMine, the biological data warehouse"
   :url "http://www.intermine.org"
@@ -102,7 +100,7 @@
   :test-paths ["test/cljs"]
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"
-                                    "resources/public/css"
+                                    "out" "resources/public/css"
                                     "test/js"]
 
   :figwheel {:css-dirs ["resources/public/css"]
@@ -152,10 +150,9 @@
                              :jar true
                              :compiler {:main bluegenes.core
                                         :output-to "resources/public/js/compiled/app.js"
-                                        ;:output-dir "resources/public/js/compiled"
+                                        :fingerprint true
                                         :optimizations :advanced
-                                        :closure-defines {goog.DEBUG false
-                                                          bluegenes.core/version ~(:version props)}
+                                        :closure-defines {goog.DEBUG false}
                                         :pretty-print false}}}}
 
   :main bluegenes.core

--- a/src/cljs/bluegenes/core.cljs
+++ b/src/cljs/bluegenes/core.cljs
@@ -14,10 +14,6 @@
             [oops.core :refer [oget oset! ocall oapply ocall! oapply!
                                oget+ oset!+ ocall+ oapply+ ocall!+ oapply!+]]))
 
-; When compiled with Advanced Compilation, bluegenes.core/version will be replaced
-; with (:version props) in project.clj
-(goog-define version "dev")
-
 ;(defn dev-setup []
 ;  (when config/debug?
 ;    (devtools/install!)

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -23,7 +23,8 @@
             [clojure.string :refer [join split]]
             [cljs.core.async :refer [put! chan <! >! timeout close!]]
             [imcljs.fetch :as fetch]
-            [bluegenes.events.registry :as registry]))
+            [bluegenes.events.registry :as registry]
+            [cljs-bean.core :refer [->clj]]))
 
 ; Change the main panel to a new view
 (reg-event-fx
@@ -60,7 +61,8 @@
      ;; Attach the client version to the saved state. This will be checked
      ;; the next time the client boots to make sure the local storage data
      ;; and the client version number are aligned.
-     {:persist [:bluegenes/state (assoc saved-keys :version bluegenes.core/version)]})))
+     {:persist [:bluegenes/state
+                (assoc saved-keys :version (:version (->clj js/serverVars)))]})))
 
 (reg-event-fx
  :save-login

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -149,7 +149,7 @@
               ;; Only use data from local storage if it's non-empty and the
               ;; client version matches.
               (and (seq state)
-                   (= bluegenes.core/version version))
+                   (= version (:version (->clj js/serverVars))))
               (assoc :current-mine (or selected-mine current-mine)
                      :mines updated-mines
                      :assets assets

--- a/src/cljs/bluegenes/pages/developer/devhome.cljs
+++ b/src/cljs/bluegenes/pages/developer/devhome.cljs
@@ -5,7 +5,8 @@
             [bluegenes.pages.developer.icons :as icons]
             [bluegenes.pages.developer.tools :as tools]
             [clojure.string :refer [blank?]]
-            [bluegenes.route :as route]))
+            [bluegenes.route :as route]
+            [cljs-bean.core :refer [->clj]]))
 
 (defn nav []
   "Buttons to choose which mine you're using."
@@ -68,7 +69,7 @@
 (defn version-number []
   [:div.panel.container
    [:h3 "Client Version: "]
-   [:code (str bluegenes.core/version)]])
+   [:code (:version (->clj js/serverVars))]])
 
 (defn localstorage-destroyer []
   (fn []


### PR DESCRIPTION
Replace appending version number to bundle URL with the ClojureScript fingerprint compiler option. This will give us unique bundle filenames when the code is changed; not just when the version number is bumped. It also allows us to keep a more standard *project.clj* by removing the need for defining the version string outside `defproject`.

Can be tested by running `lein prod` and seeing in the network panel that the bundle `app-XXXXX.js` is downloaded. Then go to the developer page and see that the same hash string is displayed under *client version*. With `lein dev` this should display `app.js` and `dev` instead.