### PR TITLE
Fix im-tables dropdowns being constrained within div

### DIFF
--- a/less/components/report/summary.less
+++ b/less/components/report/summary.less
@@ -10,7 +10,7 @@
         .table {
             margin-bottom: 0;
         }
-        overflow-x: auto;
+        overflow: visible;
     }
 
 

--- a/less/site.less
+++ b/less/site.less
@@ -288,7 +288,7 @@ label {
 }
 
 .results .im-table {
-  overflow-x: auto;
+  overflow: visible;
   margin-left: calc(100vw - 100%);
   margin-right: 0;
 }


### PR DESCRIPTION
im-tables on the report and list view pages (possibly other places they are used as well) constrain dropdowns within their parent div element. This makes navigating column summaries difficult.

![2019-11-04-121415_1191x434_scrot](https://user-images.githubusercontent.com/3865590/68122033-4ccc0500-ff01-11e9-8ceb-5a32db2a51ac.png)

This PR changes the CSS so that they are displayed overflown past their parent element, as you'd expect dropdowns to look.

We should probably ask ourselves if `overflow-x: auto;` was added to fix something else.
