### PR TITLE
Support passing POST data to start a region search

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -117,7 +117,7 @@
   :profiles {:dev {:dependencies [[binaryage/devtools "0.9.10"]
                                   [day8.re-frame/re-frame-10x "0.4.4"]
                                   [figwheel-sidecar "0.5.19"]
-                                  [cider/piggieback "0.4.1"]]
+                                  [cider/piggieback "0.4.2"]]
                    :resource-paths ["config/dev" "tools" "config/defaults"]
                    :plugins [[lein-figwheel "0.5.19"]
                              [lein-doo "0.1.8"]]}

--- a/src/clj/bluegenes/index.clj
+++ b/src/clj/bluegenes/index.clj
@@ -35,7 +35,7 @@
   [:style
    "#csscompiling{position:fixed;bottom:0;right:0;padding:20px;height:100px;width:400px;background-color:#FFA726;}"])
 
-(defn head []
+(defn head [& [req]]
   [:head
    loader-style
    css-compiling-style
@@ -56,7 +56,8 @@
                            :serviceRoot     (:bluegenes-default-service-root env)
                            :mineName        (:bluegenes-default-mine-name env)
                            :version         (or (second (re-find #"app-(.*)\.js" bundle-path))
-                                                "dev")})
+                                                "dev")
+                           :postData        (:params req)})
          ";")]
   ; Javascript:
    [:link {:rel "shortcut icon" :href "https://raw.githubusercontent.com/intermine/design-materials/f5f00be4/logos/intermine/fav32x32.png" :type "image/png"}]
@@ -90,9 +91,9 @@
 
 (defn index
   "Hiccup markup that generates the landing page and loads the necessary assets."
-  []
+  [& [req]]
   (html5
-   (head)
+   (head req)
    [:body
     (css-compiler)
     (loader)

--- a/src/clj/bluegenes/routes.clj
+++ b/src/clj/bluegenes/routes.clj
@@ -1,10 +1,11 @@
 (ns bluegenes.routes
-  (:require [compojure.core :refer [GET defroutes context]]
+  (:require [compojure.core :refer [GET POST defroutes context]]
             [compojure.route :refer [resources]]
             [ring.util.response :refer [response]]
             [bluegenes.ws.auth :as auth]
             [bluegenes.ws.ids :as ids]
-            [bluegenes.index :as index]))
+            [bluegenes.index :as index]
+            [ring.middleware.params :refer [wrap-params]]))
 
 ; Define the top level URL routes for the server
 (defroutes routes
@@ -18,4 +19,5 @@
     (context "/auth" [] auth/routes)
     (context "/ids" [] ids/routes))
 
-  (GET "*" [] (index/index)))
+  (GET "*" [] (index/index))
+  (wrap-params (POST "*" req (index/index req))))

--- a/src/cljs/bluegenes/pages/regions/events.cljs
+++ b/src/cljs/bluegenes/pages/regions/events.cljs
@@ -40,6 +40,8 @@
 (reg-event-db
  :regions/toggle-feature-type
  (fn [db [_ class]]
+   ;; If you're going to grab more properties out of `class`, make sure to
+   ;; check all uses of this event handler! (Some might not pass all.)
    (let [class-kw (keyword (:name class))
          m (get-in db [:mines (get db :current-mine) :service :model])
          descendants (keys (entity/extended-by m class-kw))

--- a/src/cljs/bluegenes/pages/regions/views.cljs
+++ b/src/cljs/bluegenes/pages/regions/views.cljs
@@ -159,15 +159,12 @@
      [checkboxes to-search settings]]))
 
 (defn main []
-  (reagent/create-class
-   {:component-did-mount #(dispatch [:regions/select-all-feature-types])
-    :reagent-render
-    (fn []
-      [:div.container.regionsearch
-       [:div.headerwithguidance
-        [:h1 "Region Search"]
-        [:a.guidance
-         {:on-click #(dispatch [:regions/set-to-search (ex)])}
-         "[Show me an example]"]]
-       [input-section]
-       [results-section]])}))
+  (fn []
+    [:div.container.regionsearch
+     [:div.headerwithguidance
+      [:h1 "Region Search"]
+      [:a.guidance
+       {:on-click #(dispatch [:regions/set-to-search (ex)])}
+       "[Show me an example]"]]
+     [input-section]
+     [results-section]]))


### PR DESCRIPTION
Pass POST params and body from bluegenes' backend to its SPA, and make it open the region search page and show the results if region data is supplied. This is to support region search queries from external pages.

To test, use an HTML like below, with bluegenes running locally.

```
<html>
  <body>
    <form action="http://localhost:5000" name="list" method="post">
			<input type="hidden" name="features" value="Allele,CDS"/>
			<input type="hidden" name="regions" value="2L:14615455..14619002
2R:5866646..5868384
3R:2578486..2580016"/>
			<input type="submit" value="Submit"/>
		</form>
  </body>
</html>
```