### PR TITLE
Support editing list description

### DIFF
--- a/cypress/integration/pr_test.js
+++ b/cypress/integration/pr_test.js
@@ -84,7 +84,9 @@ describe("UI Test", function() {
     });
   });
 
-  it("Saves the list from an upload and deletes it", function() {
+  it("Saves the list from an upload, updates the description and deletes it", function() {
+    // Upload list
+
     var listName = "Automated CI test list ".concat(Number(new Date()));
 
     cy.contains("Upload").click();
@@ -106,6 +108,23 @@ describe("UI Test", function() {
 
     cy.wait(1000);
     cy.wait("@tolist");
+
+    // Add description to list
+
+    cy.contains("Add description").click();
+    cy.get("textarea").type("My description", { delay: 100 });
+    cy.get("button")
+      .contains("Save")
+      .click();
+    // Update description to list
+    cy.contains("Edit description").click();
+    cy.get("textarea").type(" new", { delay: 100 });
+    cy.get("button")
+      .contains("Save")
+      .click();
+    cy.get(".description").contains("My description new");
+
+    // Delete list
 
     cy.contains("Data") .click();
     cy.contains(listName);

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -1,3 +1,5 @@
+@import "../variables";
+
 .breadcrumb-container {
     display: flex;
     align-items: center;
@@ -44,6 +46,27 @@
                 font-size: 0.7em;
                 text-align: right;
             }
+        }
+    }
+
+    .description {
+        background-color: #D2CEBF;
+        padding: @spacer/2;
+        overflow: auto;
+    }
+
+    .description-edit {
+        padding: @spacer/2;
+
+        .controls {
+            display: flex;
+            align-items: baseline;
+        }
+
+        p.error {
+            margin: @spacer/2;
+            color: #a94442;
+            font-weight: 500;
         }
     }
 }

--- a/src/cljs/bluegenes/pages/results/events.cljs
+++ b/src/cljs/bluegenes/pages/results/events.cljs
@@ -182,14 +182,14 @@
 
 (reg-event-fx
  :description/update-success
- (fn [{db :db} [_ {:keys [listDescription listName]}]]
+ (fn [{db :db} [_ {list-name :name list-description :description}]]
    {:dispatch [:description/edit false]
     :db (update-in db [:assets :lists (:current-mine db)]
                    (fn [lists]
                      (let [index (first (keep-indexed (fn [i {:keys [name]}]
-                                                        (when (= name listName) i))
+                                                        (when (= name list-name) i))
                                                       lists))]
-                       (assoc-in lists [index :description] listDescription))))}))
+                       (assoc-in lists [index :description] list-description))))}))
 
 (reg-event-db
  :description/update-failure

--- a/src/cljs/bluegenes/pages/results/events.cljs
+++ b/src/cljs/bluegenes/pages/results/events.cljs
@@ -166,24 +166,24 @@
       :enrichment/get-enrichment [(:widget params) enrichment-chan]})))
 
 (reg-event-db
- :description/edit
+ :list-description/edit
  (fn [db [_ state]]
    (-> db
        (assoc-in [:results :description :editing?] state)
        (assoc-in [:results :errors :description] false))))
 
 (reg-event-fx
- :description/update
+ :list-description/update
  (fn [{db :db} [_ list-name new-description]]
    (let [service (get-in db [:mines (:current-mine db) :service])]
      {:im-chan {:chan (save/im-list-update service list-name {:newDescription new-description})
-                :on-success [:description/update-success]
-                :on-failure [:description/update-failure]}})))
+                :on-success [:list-description/update-success]
+                :on-failure [:list-description/update-failure]}})))
 
 (reg-event-fx
- :description/update-success
+ :list-description/update-success
  (fn [{db :db} [_ {list-name :name list-description :description}]]
-   {:dispatch [:description/edit false]
+   {:dispatch [:list-description/edit false]
     :db (update-in db [:assets :lists (:current-mine db)]
                    (fn [lists]
                      (let [index (first (keep-indexed (fn [i {:keys [name]}]
@@ -192,7 +192,7 @@
                        (assoc-in lists [index :description] list-description))))}))
 
 (reg-event-db
- :description/update-failure
+ :list-description/update-failure
  (fn [db [_ {:keys [status body] :as res}]]
    (assoc-in db [:results :errors :description]
              (cond

--- a/src/cljs/bluegenes/pages/results/subs.cljs
+++ b/src/cljs/bluegenes/pages/results/subs.cljs
@@ -81,3 +81,13 @@
    (let [current-list (get-in db [:assets :lists (get db :current-mine)])
          list-title (get-in db [:results :query :title])]
      (->> current-list (filter #(= list-title (:title %))) first))))
+
+(reg-sub
+ :results/errors
+ (fn [db [_ kw]]
+   (get-in db [:results :errors kw])))
+
+(reg-sub
+ :description/editing?
+ (fn [db]
+   (get-in db [:results :description :editing?])))

--- a/src/cljs/bluegenes/pages/results/subs.cljs
+++ b/src/cljs/bluegenes/pages/results/subs.cljs
@@ -88,6 +88,6 @@
    (get-in db [:results :errors kw])))
 
 (reg-sub
- :description/editing?
+ :list-description/editing?
  (fn [db]
    (get-in db [:results :description :editing?])))

--- a/src/cljs/bluegenes/pages/results/views.cljs
+++ b/src/cljs/bluegenes/pages/results/views.cljs
@@ -59,7 +59,7 @@
 (defn description-input [_title initial-text]
   (let [text (reagent/atom (or initial-text ""))
         error (subscribe [:results/errors :description])
-        stop-editing #(dispatch [:description/edit false])]
+        stop-editing #(dispatch [:list-description/edit false])]
     (fn [title _initial-text]
       [:div.description-edit
        [:label "Description"]
@@ -76,13 +76,13 @@
          "Cancel"]
         [:button.btn.btn-primary.btn-raised
          {:type "button"
-          :on-click #(dispatch [:description/update title @text])}
+          :on-click #(dispatch [:list-description/update title @text])}
          "Save"]
         (when-let [e @error] [:p.error e])]])))
 
 (defn description-box []
-  (let [editing? (subscribe [:description/editing?])
-        start-editing #(dispatch [:description/edit true])]
+  (let [editing? (subscribe [:list-description/editing?])
+        start-editing #(dispatch [:list-description/edit true])]
     (fn [title description]
       (if @editing?
         [description-input title description]

--- a/src/cljs/bluegenes/pages/results/views.cljs
+++ b/src/cljs/bluegenes/pages/results/views.cljs
@@ -36,12 +36,16 @@
                     {:title title}
                     adjusted-title]])) @history))])))
 
-(defn no-results []
+(defn no-results
+  "Show an appropriate message when the list does not exist."
+  []
   [:div "Hmmm. There are no results. How did this happen? Whoopsie! "
    [:a {:href (route/href ::route/home)}
     "There's no place like home."]])
 
-(defn query-history []
+(defn query-history
+  "Gives an overview of recent queries or lists, allowing you to jump between them."
+  []
   (let [historical-queries (subscribe [:results/historical-queries])
         current-query (subscribe [:results/history-index])]
     (fn []
@@ -56,7 +60,9 @@
                      [:div.time (time-format/unparse custom-time-formatter (time-coerce/from-long last-executed))]])
                   @historical-queries))])))
 
-(defn description-input [_title initial-text]
+(defn description-input
+  "Textarea input for updating the description of a list."
+  [_title initial-text]
   (let [text (reagent/atom (or initial-text ""))
         error (subscribe [:results/errors :description])
         stop-editing #(dispatch [:list-description/edit false])]
@@ -80,7 +86,9 @@
          "Save"]
         (when-let [e @error] [:p.error e])]])))
 
-(defn description-box []
+(defn description-box
+  "Shows the list description if one is available, and let's you toggle editing."
+  []
   (let [editing? (subscribe [:list-description/editing?])
         start-editing #(dispatch [:list-description/edit true])]
     (fn [title description]
@@ -100,7 +108,9 @@
             [:svg.icon.icon-edit [:use {:xlinkHref "#icon-edit"}]]
             "Add description"]])))))
 
-(defn main []
+(defn main
+  "Result page for a list or query."
+  []
   (let [are-there-results? (subscribe [:results/are-there-results?])
         current-list (subscribe [:results/current-list])]
     (fn []


### PR DESCRIPTION
Depends on https://github.com/intermine/imcljs/pull/42.

Adds an "add description" button below the list results (and an "edit description" button instead if one is already present).

~~Note that due to a bug in https://github.com/intermine/intermine/issues/2148#issuecomment-559503248, removing an existing description is currently not possible. (Although this will probably be fixed soon.)~~
Update: The above is fixed now.
