### PR TITLE
Improvements to constraints, querybuilder, templates and mine switcher

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -147,6 +147,21 @@ Once dokku is configured on your remote host, you'll need to add your public key
 
 If you want to deploy a different branch, you can use `git push dokku dev:master` (replace *dev* with the branch you wish to deploy from).
 
+#### Deploying docker images to dokku instance
+
+You can also deploy docker images that you build locally, to the dokku instance. This is useful since it's much quicker and avoids the extra load on the dokku server from building.
+Make sure `youruser` on `dokku-server` is part of the `docker` group. This allows you to stream the file, instead of manually transferring it through ssh.
+
+```
+lein uberjar
+docker build -t dokku/appname:v1 .
+docker save dokku/appname:v1 | bzip2 | ssh youruser@dokku-server "bunzip2 | docker load"
+ssh youruser@dokku-server
+sudo dokku tags:deploy appname v1
+```
+
+Note that the tag `v1` needs to be unique for each deployment. It is common to use a version string and increment it for each deployment (might may not necessarily correspond with version releases). See the [dokku documentation](http://dokku.viewdocs.io/dokku/deployment/methods/images/#deploying-an-image-from-ci) for more information.
+
 ### Uberjar
 
 It's also possible to compile BlueGenes to a jar that will automatically launch a server when executed.

--- a/less/components/calendar.less
+++ b/less/components/calendar.less
@@ -1,0 +1,226 @@
+// Taken from https://github.com/gpbl/react-day-picker/blob/f645424337d324d7d42efd0c93e140a32c33240f/lib/style.css
+// Edit to your hearts content!
+/* DayPicker styles */
+
+.DayPicker {
+  display: inline-block;
+  font-size: 1rem;
+}
+
+.DayPicker-wrapper {
+  position: relative;
+
+  flex-direction: row;
+  padding-bottom: 1em;
+
+  -webkit-user-select: none;
+
+     -moz-user-select: none;
+
+      -ms-user-select: none;
+
+          user-select: none;
+}
+
+.DayPicker-Months {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.DayPicker-Month {
+  display: table;
+  margin: 0 1em;
+  margin-top: 1em;
+  border-spacing: 0;
+  border-collapse: collapse;
+
+  -webkit-user-select: none;
+
+     -moz-user-select: none;
+
+      -ms-user-select: none;
+
+          user-select: none;
+}
+
+.DayPicker-NavBar {
+}
+
+.DayPicker-NavButton {
+  position: absolute;
+  top: 1em;
+  right: 1.5em;
+  left: auto;
+
+  display: inline-block;
+  margin-top: 2px;
+  width: 1.25em;
+  height: 1.25em;
+  background-position: center;
+  background-size: 50%;
+  background-repeat: no-repeat;
+  color: #8B9898;
+  cursor: pointer;
+}
+
+.DayPicker-NavButton:hover {
+  opacity: 0.8;
+}
+
+.DayPicker-NavButton--prev {
+  margin-right: 1.5em;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAwCAYAAAB5R9gVAAAABGdBTUEAALGPC/xhBQAAAVVJREFUWAnN2G0KgjAYwPHpGfRkaZeqvgQaK+hY3SUHrk1YzNLay/OiEFp92I+/Mp2F2Mh2lLISWnflFjzH263RQjzMZ19wgs73ez0o1WmtW+dgA01VxrE3p6l2GLsnBy1VYQOtVSEH/atCCgqpQgKKqYIOiq2CBkqtggLKqQIKgqgCBjpJ2Y5CdJ+zrT9A7HHSTA1dxUdHgzCqJIEwq0SDsKsEg6iqBIEoq/wEcVRZBXFV+QJxV5mBtlDFB5VjYTaGZ2sf4R9PM7U9ZU+lLuaetPP/5Die3ToO1+u+MKtHs06qODB2zBnI/jBd4MPQm1VkY79Tb18gB+C62FdBFsZR6yeIo1YQiLJWMIiqVjQIu1YSCLNWFgijVjYIuhYYCKoWKAiiFgoopxYaKLUWOii2FgkophYp6F3r42W5A9s9OcgNvva8xQaysKXlFytoqdYmQH6tF3toSUo0INq9AAAAAElFTkSuQmCC');
+}
+
+.DayPicker-NavButton--next {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACQAAAAwCAYAAAB5R9gVAAAABGdBTUEAALGPC/xhBQAAAXRJREFUWAnN119ugjAcwPHWzJ1gnmxzB/BBE0n24m4xfNkTaOL7wOtsl3AXMMb+Vjaa1BG00N8fSEibPpAP3xAKKs2yjzTPH9RAjhEo9WzPr/Vm8zgE0+gXATAxxuxtqeJ9t5tIwv5AtQAApsfT6TPdbp+kUBcgVwvO51KqVhMkXKsVJFXrOkigVhCIs1Y4iKlWZxB1rX4gwlpRIIpa8SDkWmggrFq4IIRaJKCYWnSgnrXIQV1r8YD+1Vrn+bReagysIFfLABRt31v8oBu1xEBttfRbltmfjgEcWh9snUS2kNdBK6WN1vrOWxObWsz+fjxevsxmB1GQDfINWiev83nhaoiB/CoOU438oPrhXS0WpQ9xc1ZQWxWHqUYe0I0qrKCQKjygDlXIQV2r0IF6ViEBxVTBBSFUQQNhVYkHIVeJAtkNsbQ7c1LtzP6FsObhb2rCKv7NBIGoq4SDmKoEgTirXAcJVGkFSVVpgoSrXICGUMUH/QBZNSUy5XWUhwAAAABJRU5ErkJggg==');
+}
+
+.DayPicker-NavButton--interactionDisabled {
+  display: none;
+}
+
+.DayPicker-Caption {
+  display: table-caption;
+  margin-bottom: 0.5em;
+  padding: 0 0.5em;
+  text-align: left;
+}
+
+.DayPicker-Caption > div {
+  font-weight: 500;
+  font-size: 1.15em;
+}
+
+.DayPicker-Weekdays {
+  display: table-header-group;
+  margin-top: 1em;
+}
+
+.DayPicker-WeekdaysRow {
+  display: table-row;
+}
+
+.DayPicker-Weekday {
+  display: table-cell;
+  padding: 0.5em;
+  color: #8B9898;
+  text-align: center;
+  font-size: 0.875em;
+}
+
+.DayPicker-Weekday abbr[title] {
+  border-bottom: none;
+  text-decoration: none;
+}
+
+.DayPicker-Body {
+  display: table-row-group;
+}
+
+.DayPicker-Week {
+  display: table-row;
+}
+
+.DayPicker-Day {
+  display: table-cell;
+  padding: 0.5em;
+  border-radius: 50%;
+  vertical-align: middle;
+  text-align: center;
+  cursor: pointer;
+}
+
+.DayPicker-WeekNumber {
+  display: table-cell;
+  padding: 0.5em;
+  min-width: 1em;
+  border-right: 1px solid #EAECEC;
+  color: #8B9898;
+  vertical-align: middle;
+  text-align: right;
+  font-size: 0.75em;
+  cursor: pointer;
+}
+
+.DayPicker--interactionDisabled .DayPicker-Day {
+  cursor: default;
+}
+
+.DayPicker-Footer {
+  padding-top: 0.5em;
+}
+
+.DayPicker-TodayButton {
+  border: none;
+  background-color: transparent;
+  background-image: none;
+  box-shadow: none;
+  color: #4A90E2;
+  font-size: 0.875em;
+  cursor: pointer;
+}
+
+/* Default modifiers */
+
+.DayPicker-Day--today {
+  color: #D0021B;
+  font-weight: 700;
+}
+
+.DayPicker-Day--outside {
+  color: #8B9898;
+  cursor: default;
+}
+
+.DayPicker-Day--disabled {
+  color: #DCE0E0;
+  cursor: default;
+  /* background-color: #eff1f1; */
+}
+
+/* Example modifiers */
+
+.DayPicker-Day--sunday {
+  background-color: #F7F8F8;
+}
+
+.DayPicker-Day--sunday:not(.DayPicker-Day--today) {
+  color: #DCE0E0;
+}
+
+.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
+  position: relative;
+
+  background-color: #4A90E2;
+  color: #F0F8FF;
+}
+
+.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside):hover {
+  background-color: #51A0FA;
+}
+
+.DayPicker:not(.DayPicker--interactionDisabled)
+  .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover {
+  background-color: #F0F8FF;
+}
+
+/* DayPickerInput */
+
+.DayPickerInput {
+  display: inline-block;
+}
+
+.DayPickerInput-OverlayWrapper {
+  position: relative;
+}
+
+.DayPickerInput-Overlay {
+  position: absolute;
+  left: 0;
+  z-index: 1;
+
+  background: white;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+}

--- a/less/components/constraints.less
+++ b/less/components/constraints.less
@@ -1,0 +1,10 @@
+@import "../variables";
+
+.list-dropdown {
+    .dropdown-toggle {
+        text-transform: none;
+        white-space: normal;
+        margin-top: 0;
+    }
+}
+

--- a/less/components/login.less
+++ b/less/components/login.less
@@ -41,6 +41,12 @@
         align-items: center;
         justify-content: flex-end;
 
+        .mine-logo {
+            width: @spacer*2;
+            max-height: @spacer*2;
+            margin-right: @spacer/2;
+        }
+
         .other-action {
             margin-right: @spacer;
         }

--- a/less/components/navbar.less
+++ b/less/components/navbar.less
@@ -112,6 +112,7 @@
             .active-mine-image {
                 width: @spacer*2;
                 max-height: @spacer*2;
+                margin-right: @spacer/2;
             }
             &:hover {
                 .transitions;

--- a/less/components/navbar.less
+++ b/less/components/navbar.less
@@ -86,6 +86,10 @@
                         border-top: solid 1px @highlight-color;
                     }
                 }
+                li a.current {
+                    background-color: #d8ebf5;
+                    font-weight: bold;
+                }
             }
         }
         .minename {
@@ -104,6 +108,10 @@
                 margin-top: -4px;
                 margin-right: 2px;
                 margin-left: 0;
+            }
+            .active-mine-image {
+                width: @spacer*2;
+                max-height: @spacer*2;
             }
             &:hover {
                 .transitions;

--- a/less/components/querybuilder.less
+++ b/less/components/querybuilder.less
@@ -879,12 +879,6 @@ div.column-container {
 }
 
 .constraint-input {
-    // input[type="text"] {
-    //     transition: .4s;
-    // }
-    // I had to disable the above since it was overly general and ended up
-    // targetting react-select, causing the text to slowly jump around when
-    // inputted. I couldn't find its intended effect so I disabled it.
     .disabled {
         color: grey;
         fill: grey;

--- a/less/components/querybuilder.less
+++ b/less/components/querybuilder.less
@@ -472,6 +472,7 @@ div.column-container {
             display: flex;
             align-items: center;
             justify-content: center;
+            height: 1.8*@spacer;
         }
     }
 
@@ -485,6 +486,12 @@ div.column-container {
             min-width: 1em;
             min-height: 1em;
         }
+    }
+
+    // Applies to react-select third-party component.
+    .constraint-select {
+        width: 100%;
+        font-size: 14px;
     }
 }
 
@@ -872,9 +879,12 @@ div.column-container {
 }
 
 .constraint-input {
-    input[type="text"] {
-        transition: .4s;
-    }
+    // input[type="text"] {
+    //     transition: .4s;
+    // }
+    // I had to disable the above since it was overly general and ended up
+    // targetting react-select, causing the text to slowly jump around when
+    // inputted. I couldn't find its intended effect so I disabled it.
     .disabled {
         color: grey;
         fill: grey;

--- a/less/components/querybuilder.less
+++ b/less/components/querybuilder.less
@@ -59,7 +59,7 @@ div.column-container {
         padding: 20px;
         flex: 1 0;
         background-color: #fbfbfb;
-        overflow-y: scroll;
+        overflow: auto;
 
         p {
             margin: @spacer 0 @spacer/2 0;
@@ -352,7 +352,6 @@ div.column-container {
     background-color: @query-browser-bg;
     color: @query-browser-fg;
     padding: 0 20px 20px;
-    overflow: auto;
 
     li.tree,
     ul.tree {

--- a/less/components/querybuilder.less
+++ b/less/components/querybuilder.less
@@ -208,6 +208,12 @@ div.column-container {
             white-space: pre-wrap;
             word-break: break-word;
         }
+
+        .query-preview-loader {
+            position: relative;
+            top: 0.4*@spacer;
+            left: 0.4*@spacer;
+        }
     }
 }
 

--- a/less/components/templates.less
+++ b/less/components/templates.less
@@ -34,6 +34,16 @@
     .preview {
         max-width: 60vw;
         overflow-x: "hidden";
+
+        .preview-header {
+            display: flex;
+
+            .preview-header-loader {
+                position: relative;
+                top: 0.6*@spacer;
+                left: 0.6*@spacer;
+            }
+        }
     }
 
     .view-results {

--- a/less/site.less
+++ b/less/site.less
@@ -20,6 +20,7 @@
 @import "components/organize";
 @import "components/profile";
 @import "components/ui/inputs";
+@import "components/calendar";
 @import "layouts/input-group";
 @import "layouts/header";
 @import "developer";

--- a/less/site.less
+++ b/less/site.less
@@ -34,7 +34,7 @@ body {
   background: @body-background-color;
   color: @body-foreground-color;
   margin-top: 50px;
-  font-family: 'Roboto', sans-serif;
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
 }
 
 .ani {

--- a/less/site.less
+++ b/less/site.less
@@ -21,6 +21,7 @@
 @import "components/profile";
 @import "components/ui/inputs";
 @import "components/calendar";
+@import "components/constraints";
 @import "layouts/input-group";
 @import "layouts/header";
 @import "developer";

--- a/project.clj
+++ b/project.clj
@@ -22,6 +22,7 @@
                  [servant "0.1.5"]
                  [json-html "0.4.7"]
                  [markdown-to-hiccup "0.6.2"]
+                 [cljsjs/react-day-picker "7.3.0-1"]
 
                  ; HTTP
                  [clj-http "3.10.0"]

--- a/project.clj
+++ b/project.clj
@@ -23,6 +23,7 @@
                  [json-html "0.4.7"]
                  [markdown-to-hiccup "0.6.2"]
                  [cljsjs/react-day-picker "7.3.0-1"]
+                 [cljsjs/react-select "2.4.4-0"]
 
                  ; HTTP
                  [clj-http "3.10.0"]

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -7,6 +7,8 @@
             [bluegenes.route :as route]
             [bluegenes.components.ui.inputs :refer [password-input]]))
 
+(def ^:const logo-path "/model/images/logo.png")
+
 (defn mine-icon
   "returns the icon set for a specific mine, or a default.
    Pass it the entire set of mine details, e.g.
@@ -15,8 +17,7 @@
   [:img
    {:class class
     :src (or (get-in details [:images :logo])
-             (str (get-in details [:service :root])
-                  "/model/images/logo.png"))}])
+             (str (get-in details [:service :root]) logo-path))}])
 
 (defn update-form [atom key evt]
   (swap! atom assoc key (oget evt :target :value)))
@@ -124,9 +125,10 @@
 
 (defn active-mine-logo []
   (let [current-mine @(subscribe [:current-mine])
+        logo (get-in current-mine [:logo])
         service (get-in current-mine [:service :root])]
     [:img.active-mine-image
-     {:src (str service "/model/images/logo.png")}]))
+     {:src (or logo (str service logo-path))}]))
 
 (defn main []
   (let [active-panel (subscribe [:active-panel])

--- a/src/cljs/bluegenes/components/navbar/nav.cljs
+++ b/src/cljs/bluegenes/components/navbar/nav.cljs
@@ -11,33 +11,28 @@
   "returns the icon set for a specific mine, or a default.
    Pass it the entire set of mine details, e.g.
    (subscribe [:current-mine])."
-  [mine]
-  (let [icon (:icon mine)]
-    [:svg.icon.logo {:class icon}
-     [:use {:xlinkHref (str "#" icon)}]]))
+  [details & {:keys [class]}]
+  [:img
+   {:class class
+    :src (or (get-in details [:images :logo])
+             (str (get-in details [:service :root])
+                  "/model/images/logo.png"))}])
 
 (defn update-form [atom key evt]
   (swap! atom assoc key (oget evt :target :value)))
 
 (defn mine-entry
   "Output a single mine in the mine picker"
-  [mine-key details]
+  [mine-key details & {:keys [current?]}]
   [:li
    {:title (:description details)}
-   [:a {:href (route/href ::route/home {:mine mine-key})}
-    [:img {:src (:logo (:images details))}]
+   [:a (if current?
+         {:class "current"}
+         {:href (route/href ::route/home {:mine mine-key})})
+    [mine-icon details]
     (str (:name details)
          (when (= mine-key :default)
            " (default)"))]])
-
-(defn mine-entry-current
-  "Output a single mine in the mine picker"
-  [details]
-  [:li
-   {:title (:description details)}
-   [:a [mine-icon details]
-    [:img {:src (:logo (:images details))}]
-    (:name details) " (current)"]])
 
 (defn settings
   "output the settings menu and mine picker"
@@ -48,14 +43,12 @@
      [:a.dropdown-toggle {:data-toggle "dropdown" :role "button"}
       [:svg.icon.icon-cog [:use {:xlinkHref "#icon-cog"}]]]
      (conj
-      (into
-       [:ul.dropdown-menu
-        [mine-entry-current (get registry-with-default current-mine-name)]]
-       (map (fn [[mine-key details]]
-              ^{:key mine-key}
-              [mine-entry mine-key details])
-            (sort-by (comp :name val)
-                     (dissoc registry-with-default current-mine-name))))
+      (into [:ul.dropdown-menu]
+            (map (fn [[mine-key details]]
+                   ^{:key mine-key}
+                   [mine-entry mine-key details
+                    :current? (= mine-key current-mine-name)])
+                 (sort-by (comp :name val) registry-with-default)))
       [:li.special
        [:a {:href (route/href ::route/debug {:panel "main"})}
         ">_ Developer"]])]))
@@ -117,7 +110,7 @@
             [:button.btn.btn-primary.btn-raised
              {:type "button"
               :on-click submit-fn}
-             [mine-icon @current-mine]
+             [mine-icon @current-mine :class "mine-logo"]
              (if @register? "Register" "Sign In")]]
            (when error?
              [:div.alert.alert-danger.error-box message])]]]))))
@@ -130,7 +123,10 @@
         [anonymous]))))
 
 (defn active-mine-logo []
-  [mine-icon @(subscribe [:current-mine])])
+  (let [current-mine @(subscribe [:current-mine])
+        service (get-in current-mine [:service :root])]
+    [:img.active-mine-image
+     {:src (str service "/model/images/logo.png")}]))
 
 (defn main []
   (let [active-panel (subscribe [:active-panel])

--- a/src/cljs/bluegenes/components/ui/constraint.cljs
+++ b/src/cljs/bluegenes/components/ui/constraint.cljs
@@ -103,7 +103,8 @@
 (defn read-day-change
   "Convert DayPicker input to the string we use as constraint."
   [date _mods picker]
-  (let [input (.-value (.getInput picker))]
+  (let [input (-> (ocall picker :getInput)
+                  (oget :value))]
     ;; `date` can be nil if it's not a valid date. We use the raw input text in
     ;; that case, to accomodate alien calendars.
     (or (some->> date

--- a/src/cljs/bluegenes/components/ui/constraint.cljs
+++ b/src/cljs/bluegenes/components/ui/constraint.cljs
@@ -121,7 +121,8 @@
       (cond
         (= type "java.util.Date")
         [:> js/DayPicker.Input
-         {:value (or value "")
+         {:inputProps {:class "form-control"}
+          :value (or value "")
           :placeholder "YYYY-MM-DD"
           :formatDate (fn [date _ _]
                         (if (instance? js/Date date)

--- a/src/cljs/bluegenes/components/ui/constraint.cljs
+++ b/src/cljs/bluegenes/components/ui/constraint.cljs
@@ -152,7 +152,6 @@
                  :class (when disabled "disabled")
                  :value (or value "")
                  :on-change (fn [e]
-                              (on-change (oget e :target :value))
                               (on-blur (oget e :target :value)))}]
                (cond-> (map (fn [v] [:option {:value v} v]) (remove nil? possible-values))
                  (blank? value) (conj
@@ -175,7 +174,6 @@
                  :value (or value [])
                  :on-change (fn [e]
                               (let [value (doall (map first (filter (fn [[k elem]] (oget elem :selected)) @multiselects)))]
-                                (on-change value)
                                 (on-blur value)))}]
                (map (fn [v]
                       [:option
@@ -193,7 +191,6 @@
          :disabled disabled
          :restrict-type (im-path/class model path)
          :on-change (fn [list]
-                      ((or on-select-list on-change) list)
                       (on-blur list))]
 
         :else
@@ -231,11 +228,11 @@
               :value op
               :on-change (fn [e]
                            (let [new-op (oget e :target :value)]
-                             (on-change (oget e :target :value))
-                             ; Only fire the on-blur event when the operator has not changed from
-                             ; a non-list operator to a list-operator.
-                             ; Switching from "= Protein Domain" to "IN Protein Domain" doesn't make sense!
-                             (when-not (and (one-of? new-op ["IN" "NOT IN"]) (not-one-of? op ["IN" "NOT IN"]))
+                             (if (and (one-of? new-op ["IN" "NOT IN"]) (not-one-of? op ["IN" "NOT IN"]))
+                               (on-change (oget e :target :value))
+                               ; Only fire the on-blur event when the operator has not changed from
+                               ; a non-list operator to a list-operator.
+                               ; Switching from "= Protein Domain" to "IN Protein Domain" doesn't make sense!
                                (on-blur (oget e :target :value)))))}]
             (as-> operators $
               (filter (partial applies-to? (im-path/data-type model path)) $)

--- a/src/cljs/bluegenes/components/ui/constraint.cljs
+++ b/src/cljs/bluegenes/components/ui/constraint.cljs
@@ -23,25 +23,25 @@
                  :applies-to [nil]}
                 {:op "="
                  :label "="
-                 :applies-to ["java.lang.String" "java.lang.Boolean" "java.lang.Integer" "java.lang.Double" "java.lang.Float"]}
+                 :applies-to ["java.lang.String" "java.lang.Boolean" "java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"]}
                 {:op "!="
                  :label "!="
-                 :applies-to ["java.lang.String" "java.lang.Boolean" "java.lang.Integer" "java.lang.Double" "java.lang.Float"]}
+                 :applies-to ["java.lang.String" "java.lang.Boolean" "java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"]}
                 {:op "CONTAINS"
                  :label "Contains"
                  :applies-to ["java.lang.String"]}
                 {:op "<"
                  :label "<"
-                 :applies-to ["java.lang.Integer" "java.lang.Double" "java.lang.Float"]}
+                 :applies-to ["java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"]}
                 {:op "<="
                  :label "<="
-                 :applies-to ["java.lang.Integer" "java.lang.Double" "java.lang.Float"]}
+                 :applies-to ["java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"]}
                 {:op ">"
                  :label ">"
-                 :applies-to ["java.lang.Integer" "java.lang.Double" "java.lang.Float"]}
+                 :applies-to ["java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"]}
                 {:op ">="
                  :label ">="
-                 :applies-to ["java.lang.Integer" "java.lang.Double" "java.lang.Float"]}
+                 :applies-to ["java.lang.Integer" "java.lang.Double" "java.lang.Float" "java.util.Date"]}
                 {:op "LIKE"
                  :label "Like"
                  :applies-to ["java.lang.String"]}
@@ -50,10 +50,10 @@
                  :applies-to ["java.lang.String"]}
                 {:op "ONE OF"
                  :label "One of"
-                 :applies-to ["java.lang.String"]}
+                 :applies-to ["java.lang.String" "java.util.Date"]}
                 {:op "NONE OF"
                  :label "None of"
-                 :applies-to ["java.lang.String"]}])
+                 :applies-to ["java.lang.String" "java.util.Date"]}])
 
 (defn applies-to?
   "Given a field type (ex java.lang.Double) return all constraint maps that support that type"

--- a/src/cljs/bluegenes/components/ui/constraint.cljs
+++ b/src/cljs/bluegenes/components/ui/constraint.cljs
@@ -116,12 +116,12 @@
   []
   (let [multiselects (reagent/atom {})
         focused? (reagent/atom false)]
-    (fn [& {:keys [model path value typeahead? on-change on-blur _code lists
+    (fn [& {:keys [model path value typeahead? on-change on-blur _code lists type
                    _allow-possible-values possible-values disabled op on-select-list]}]
       (cond
-        (= (im-path/data-type model path) "java.util.Date")
+        (= type "java.util.Date")
         [:> js/DayPicker.Input
-         {:value value
+         {:value (or value "")
           :placeholder "YYYY-MM-DD"
           :formatDate (fn [date _ _]
                         (if (instance? js/Date date)
@@ -139,7 +139,9 @@
           :onDayChange (comp on-change read-day-change)
           :onDayPickerHide #(on-blur value)}]
 
-        (and (and typeahead? (seq? possible-values))
+        (and (not= type "java.lang.Integer")
+             typeahead?
+             (seq? possible-values)
              (or (= op "=")
                  (= op "!=")))
         [:div.constraint-text-input
@@ -307,6 +309,7 @@
                               :code code
                               :lists lists
                               :disabled disabled
+                              :type (im-path/data-type model path)
                               :allow-possible-values (and (not= op "IN") (not= op "NOT IN"))
                               :possible-values @pv
                               :on-change (fn [val]
@@ -354,6 +357,7 @@
                                         :typeahead? typeahead?
                                         :path path
                                         :disabled disabled
+                                        :type (im-path/data-type model path)
                                         :allow-possible-values (and (not= op "IN") (not= op "NOT IN"))
                                         :possible-values @pv
                                         :on-change (fn [val]

--- a/src/cljs/bluegenes/components/ui/list_dropdown.cljs
+++ b/src/cljs/bluegenes/components/ui/list_dropdown.cljs
@@ -36,23 +36,22 @@
        :on-change   (fn [e] (reset! text-filter-atom (oget e :target :value)))
        :placeholder "Filter..."}]]))
 
-(defn list-dropdown []
+(defn list-dropdown
   "Creates a dropdown for intermine lists
   :value          The selected value to show in the dropdown
   :lists          A collection of Intermine lists
   :restrict-type  (Optional) a keyword to restrict the list to a type, like :Gene
   :on-change      A function to call with the name of the list"
+  []
   (let [text-filter-atom (reagent/atom nil)]
     (fn [& {:keys [value lists restrict-type on-change disabled :as x]}]
       (let [text-filter    (partial has-text? @text-filter-atom)
             type-filter    (partial has-type? restrict-type)
             filter-fn      (apply every-pred [text-filter type-filter])
             filtered-lists (filter filter-fn lists)]
-        [:div.dropdown
+        [:div.dropdown.list-dropdown
          [:button.btn.btn-raised.btn-default.dropdown-toggle
           {:disabled disabled
-           :style       {:text-transform "none"
-                         :white-space    "normal"}
            :data-toggle "dropdown"}
           (str (or value "Choose a list") " ") [:span.caret]]
          [:div.dropdown-menu.dropdown-mixed-content

--- a/src/cljs/bluegenes/components/ui/list_dropdown.cljs
+++ b/src/cljs/bluegenes/components/ui/list_dropdown.cljs
@@ -44,30 +44,34 @@
   :on-change      A function to call with the name of the list"
   []
   (let [text-filter-atom (reagent/atom nil)]
-    (fn [& {:keys [value lists restrict-type on-change disabled :as x]}]
-      (let [text-filter    (partial has-text? @text-filter-atom)
-            type-filter    (partial has-type? restrict-type)
-            filter-fn      (apply every-pred [text-filter type-filter])
-            filtered-lists (filter filter-fn lists)]
+    (fn [& {:keys [value lists restrict-type on-change disabled]}]
+      (let [type-filter    (partial has-type? restrict-type)
+            text-filter    (partial has-text? @text-filter-atom)
+            suitable-lists (filter type-filter lists)
+            filtered-lists (filter text-filter suitable-lists)]
         [:div.dropdown.list-dropdown
          [:button.btn.btn-raised.btn-default.dropdown-toggle
           {:disabled disabled
            :data-toggle "dropdown"}
           (str (or value "Choose a list") " ") [:span.caret]]
          [:div.dropdown-menu.dropdown-mixed-content
-          (if (some? (not-empty lists))
+          (if (seq suitable-lists)
             [:div.container-fluid
              [text-filter-form text-filter-atom]
-             [:div.col-md-6
-              [:h4 [:svg.icon.icon-history [:use {:xlinkHref "#icon-history"}]] " Recently Created"]
-              [im-lists
-               :lists (take 5 (sort-by :timestamp filtered-lists))
-               :on-change on-change]]
-             [:div.col-md-6
-              [:h4 [:svg.icon.icon-sort-alpha-asc [:use {:xlinkHref "#icon-sort-alpha-asc"}]] " All Lists"]
-              [:div.clip-400
-               [im-lists
-                :lists (sort-by :name filtered-lists)
-                :on-change on-change]]]]
+             (if (seq filtered-lists)
+               [:<>
+                [:div.col-md-6
+                 [:h4 [:svg.icon.icon-history [:use {:xlinkHref "#icon-history"}]] " Recently Created"]
+                 [im-lists
+                  :lists (take 5 (sort-by :timestamp filtered-lists))
+                  :on-change on-change]]
+                [:div.col-md-6
+                 [:h4 [:svg.icon.icon-sort-alpha-asc [:use {:xlinkHref "#icon-sort-alpha-asc"}]] " All Lists"]
+                 [:div.clip-400
+                  [im-lists
+                   :lists (sort-by :name filtered-lists)
+                   :on-change on-change]]]]
+               [:div.container-fluid
+                [:h4 (str "No suitable lists containing \"" @text-filter-atom "\"")]])]
             [:div.container-fluid
-             [:h4 (str "No lists available of type " restrict-type)]])]]))))
+             [:h4 (str "No lists available of type " (name restrict-type))]])]]))))

--- a/src/cljs/bluegenes/core.cljs
+++ b/src/cljs/bluegenes/core.cljs
@@ -11,6 +11,7 @@
             [bluegenes.pages.templates.core]
             [cljsjs.google-analytics]
             [cljsjs.react-transition-group]
+            [cljsjs.react-day-picker]
             [oops.core :refer [ocall]]))
 
 ;(defn dev-setup []

--- a/src/cljs/bluegenes/core.cljs
+++ b/src/cljs/bluegenes/core.cljs
@@ -12,6 +12,7 @@
             [cljsjs.google-analytics]
             [cljsjs.react-transition-group]
             [cljsjs.react-day-picker]
+            [cljsjs.react-select]
             [oops.core :refer [ocall]]))
 
 ;(defn dev-setup []

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -204,7 +204,8 @@
  (fn [db [_ mine-kw view-vec results]]
    (if (false? results)
      (assoc-in db [:mines mine-kw :possible-values view-vec] false)
-     (assoc-in db [:mines mine-kw :possible-values view-vec] (not-empty (map :item (:results results)))))))
+     (assoc-in db [:mines mine-kw :possible-values view-vec]
+               (not-empty (sort (map :item (:results results))))))))
 
 (reg-fx
  :cache/fetch-possible-values-fx

--- a/src/cljs/bluegenes/events/boot.cljs
+++ b/src/cljs/bluegenes/events/boot.cljs
@@ -323,10 +323,12 @@
 (reg-event-db
  :assets/success-fetch-model
  (fn [db [_ mine-kw model]]
-   (-> db
-       (assoc-in [:mines mine-kw :service :model] model)
-       (assoc-in [:mines mine-kw :default-object-types]
-                 (sort (preferred-fields model))))))
+   (let [model' (update model :classes
+                        #(into {} (filter (comp pos? :count val) %)))]
+     (-> db
+         (assoc-in [:mines mine-kw :service :model] model')
+         (assoc-in [:mines mine-kw :default-object-types]
+                   (sort (preferred-fields model')))))))
 
 (reg-event-fx
  :assets/fetch-model

--- a/src/cljs/bluegenes/pages/querybuilder/events.cljs
+++ b/src/cljs/bluegenes/pages/querybuilder/events.cljs
@@ -82,10 +82,9 @@
 (reg-event-fx
  :qb/add-constraint
  (fn [{db :db} [_ view-vec]]
-   (let [code (next-available-const-code (get-in db loc))]
-     {:db (update-in db loc update-in (conj view-vec :constraints)
-                     (comp vec conj) {:code nil :op nil :value nil})
-      :dispatch [:qb/build-im-query]})))
+   {:db (update-in db loc update-in (conj view-vec :constraints)
+                   (comp vec conj) {:code nil :op nil :value nil})
+    :dispatch [:qb/build-im-query]}))
 
 (reg-event-fx
  :qb/remove-constraint
@@ -101,7 +100,7 @@
    (let [updated-constraint (cond-> constraint
                               (and
                                (blank? (:code constraint))
-                               (not-blank? (:value constraint))) (assoc :code (next-available-const-code (get-in db loc)))
+                               (not-blank? (:value constraint))) (assoc :code (next-available-const-code (get-in db [:qb :enhance-query])))
                               (blank? (:value constraint)) (dissoc :code))]
      (update-in db loc assoc-in (reduce conj path [:constraints idx]) updated-constraint))))
 
@@ -403,11 +402,10 @@
 (reg-event-fx
  :qb/enhance-query-add-constraint
  (fn [{db :db} [_ view-vec]]
-   (let [code (next-available-const-code (get-in db [:qb :enhance-query]))]
-     {:db (update-in db [:qb :enhance-query] update-in (conj view-vec :constraints)
-                     (comp vec conj) {:code nil :op nil :value nil})
-      :dispatch-n [[:cache/fetch-possible-values (join "." view-vec)]
-                   [:qb/fetch-possible-values view-vec]]})))
+   {:db (update-in db [:qb :enhance-query] update-in (conj view-vec :constraints)
+                   (comp vec conj) {:code nil :op nil :value nil})
+    :dispatch-n [[:cache/fetch-possible-values (join "." view-vec)]
+                 [:qb/fetch-possible-values view-vec]]}))
 ;:dispatch [:qb/build-im-query]
 
 

--- a/src/cljs/bluegenes/pages/querybuilder/events.cljs
+++ b/src/cljs/bluegenes/pages/querybuilder/events.cljs
@@ -420,7 +420,8 @@
       :dispatch [:qb/enhance-query-build-im-query true]})))
 ;:dispatch [:qb/build-im-query]
 
-
+;; Having both `:value` and `:values` keys makes this bug-prone. If we find we need
+;; to refactor this, we should merge it into a single polymorphic `:value` key.
 (reg-event-db
  :qb/enhance-query-update-constraint
  (fn [db [_ path idx constraint]]

--- a/src/cljs/bluegenes/pages/querybuilder/views.cljs
+++ b/src/cljs/bluegenes/pages/querybuilder/views.cljs
@@ -299,9 +299,10 @@
                                    :typeahead? true
                                    :value (or (:value con) (:values con))
                                    :op (:op con)
-                                   ;; Having the following four functions is prone to bugs. If you have the need to
-                                   ;; refactor these, turn them into two functions instead: on-update and on-build.
-                                   ;; Then the children can decide whether they wish to call the first, last or both.
+                                   ;; Do we need all these? I think it would be simpler to just have:
+                                   ;;     on-change - update state
+                                   ;;     on-blur   - update state and rerun query
+                                   ;; If you find you need to refactor these, try converting it to the above.
                                    :on-select-list (fn [c]
                                                      (dispatch [:qb/enhance-query-update-constraint path idx c])
                                                      (dispatch [:qb/enhance-query-build-im-query true]))

--- a/src/cljs/bluegenes/pages/querybuilder/views.cljs
+++ b/src/cljs/bluegenes/pages/querybuilder/views.cljs
@@ -290,23 +290,20 @@
                                    :typeahead? true
                                    :value (or (:value con) (:values con))
                                    :op (:op con)
+                                   ;; Having the following four functions is prone to bugs. If you have the need to
+                                   ;; refactor these, turn them into two functions instead: on-update and on-build.
+                                   ;; Then the children can decide whether they wish to call the first, last or both.
                                    :on-select-list (fn [c]
                                                      (dispatch [:qb/enhance-query-update-constraint path idx c])
                                                      (dispatch [:qb/enhance-query-build-im-query true]))
                                    :on-change-operator (fn [x]
                                                          (dispatch [:qb/enhance-query-update-constraint path idx x])
                                                          (dispatch [:qb/enhance-query-build-im-query true]))
-
                                    :on-change (fn [c]
                                                 (dispatch [:qb/enhance-query-update-constraint path idx c]))
-                                                ;(dispatch [:qb/enhance-query-build-im-query true])
-
                                    :on-blur (fn [c]
                                               (dispatch [:qb/enhance-query-update-constraint path idx c])
                                               (dispatch [:qb/enhance-query-build-im-query true]))
-
-                                   ;(dispatch [:qb/build-im-query])
-
                                    :label? false]]]) constraints)))
          (when (not-empty (dissoc-keywords properties))
            (let [classes (filter (fn [[k p]] (im-path/class? model (join "." (conj path k)))) (dissoc-keywords properties))

--- a/src/cljs/bluegenes/pages/querybuilder/views.cljs
+++ b/src/cljs/bluegenes/pages/querybuilder/views.cljs
@@ -369,7 +369,8 @@
         submit-fn #(when-let [title (not-empty @query-title)]
                      (swap! saving-query? not)
                      (reset! query-title "")
-                     (dispatch [:qb/save-query title]))]
+                     (dispatch [:qb/save-query title]))
+        fetching-preview? (subscribe [:qb/fetching-preview?])]
     (fn []
       (if @saving-query?
         [:div.button-group
@@ -397,11 +398,13 @@
           "Save Query"]
          [:button.btn.btn-raised
           {:on-click (fn [] (dispatch [:qb/enhance-query-clear-query]))}
-          "Clear Query"]]))))
+          "Clear Query"]
+         (when @fetching-preview?
+           [:div.query-preview-loader
+            [mini-loader "tiny"]])]))))
 
 (defn preview [result-count]
-  (let [results-preview (subscribe [:qb/preview])
-        fetching-preview? (subscribe [:qb/fetching-preview?])]
+  (let [results-preview (subscribe [:qb/preview])]
     [:div.preview-container
      (if-let [res @results-preview]
        [preview-table

--- a/src/cljs/bluegenes/pages/templates/events.cljs
+++ b/src/cljs/bluegenes/pages/templates/events.cljs
@@ -18,12 +18,12 @@
  (fn [{db :db} [_ id]]
    (let [current-mine (:current-mine db)
          query (get-in db [:assets :templates current-mine id])]
-     {:db (update-in db [:components :template-chooser]
-                     assoc
+     {:db (update-in db [:components :template-chooser] assoc
                      :selected-template query
                      :selected-template-name id
                      :selected-template-service (get-in db [:mines current-mine :service])
-                     :count nil)
+                     :count nil
+                     :results-preview nil)
       :dispatch-n [[:template-chooser/run-count]
                    [:template-chooser/fetch-preview]]})))
 

--- a/src/cljs/bluegenes/pages/templates/views.cljs
+++ b/src/cljs/bluegenes/pages/templates/views.cljs
@@ -30,33 +30,31 @@
 (def css-transition-group
   (reagent/adapt-react-class js/ReactTransitionGroup.CSSTransitionGroup))
 
-(defn results-count-text [results-preview]
-  (if (< (:iTotalRecords @results-preview) 1)
-    "No Results"
-    (str "View "
-         (js/parseInt (:iTotalRecords @results-preview))
-         (if (> (:iTotalRecords @results-preview) 1) " rows" " row"))))
-
 (defn preview-results
   "Preview results of template as configured by the user or default config"
   [results-preview fetching-preview]
   (let [fetching-preview? (subscribe [:template-chooser/fetching-preview?])
-        results-preview (subscribe [:template-chooser/results-preview])]
+        results-preview (subscribe [:template-chooser/results-preview])
+        loading? (or @fetching-preview? (nil? @results-preview))
+        results-count (:iTotalRecords @results-preview)]
     [:div.col-xs-8.preview
      [:div.preview-header
        [:h4 "Results Preview"]
-       (when @fetching-preview?
+       (when loading?
          [:div.preview-header-loader
           [mini-loader "tiny"]])]
      [preview-table
       :query-results @results-preview]
      [:button.btn.btn-primary.btn-raised.view-results
       {:type "button"
-       :disabled (< (:iTotalRecords @results-preview) 1)
+       :disabled (zero? results-count)
        :on-click (fn [] (dispatch [:templates/send-off-query]))}
-      (if @fetching-preview?
-        "Loading"
-        (results-count-text results-preview))]]))
+      (cond
+        loading? "Loading"
+        (zero? results-count) "No Results"
+        :else (str "View "
+                   results-count
+                   (if (> results-count 1) " rows" " row")))]]))
 
 (defn toggle []
   (fn [{:keys [status on-change]}]

--- a/src/cljs/bluegenes/pages/templates/views.cljs
+++ b/src/cljs/bluegenes/pages/templates/views.cljs
@@ -68,7 +68,7 @@
   [selected-template]
   (let [service (subscribe [:selected-template-service])
         row-count (subscribe [:template-chooser/count])
-        lists (subscribe [:lists])]
+        lists (subscribe [:current-lists])]
     [:div.col-xs-4.border-right
      (into [:div.form]
            ; Only show editable constraints, but don't filter because we want the index!
@@ -86,8 +86,12 @@
                          :hide-code? true
                          :label? true
                          :disabled (= switched "OFF")
-                         :lists (second (first @lists))
+                         :lists @lists
                          :on-blur (fn [new-constraint]
+                                    (dispatch [:template-chooser/replace-constraint
+                                               idx (merge (cond-> con
+                                                            (contains? new-constraint :values) (dissoc :value)
+                                                            (contains? new-constraint :value) (dissoc :values)) new-constraint)])
                                     (dispatch [:template-chooser/update-preview
                                                idx (merge (cond-> con
                                                             (contains? new-constraint :values) (dissoc :value)

--- a/src/cljs/bluegenes/pages/templates/views.cljs
+++ b/src/cljs/bluegenes/pages/templates/views.cljs
@@ -8,7 +8,8 @@
             [bluegenes.components.ui.constraint :refer [constraint]]
             [bluegenes.components.ui.results_preview :refer [preview-table]]
             [oops.core :refer [oget ocall]]
-            [clojure.string :as s]))
+            [clojure.string :as s]
+            [bluegenes.components.loader :refer [mini-loader]]))
 
 (defn categories []
   (let [categories (subscribe [:template-chooser-categories])
@@ -42,9 +43,12 @@
   (let [fetching-preview? (subscribe [:template-chooser/fetching-preview?])
         results-preview (subscribe [:template-chooser/results-preview])]
     [:div.col-xs-8.preview
-     [:h4 "Results Preview"]
+     [:div.preview-header
+       [:h4 "Results Preview"]
+       (when @fetching-preview?
+         [:div.preview-header-loader
+          [mini-loader "tiny"]])]
      [preview-table
-      :loading? @fetching-preview?
       :query-results @results-preview]
      [:button.btn.btn-primary.btn-raised.view-results
       {:type "button"

--- a/src/cljs/bluegenes/pages/templates/views.cljs
+++ b/src/cljs/bluegenes/pages/templates/views.cljs
@@ -39,10 +39,10 @@
         results-count (:iTotalRecords @results-preview)]
     [:div.col-xs-8.preview
      [:div.preview-header
-       [:h4 "Results Preview"]
-       (when loading?
-         [:div.preview-header-loader
-          [mini-loader "tiny"]])]
+      [:h4 "Results Preview"]
+      (when loading?
+        [:div.preview-header-loader
+         [mini-loader "tiny"]])]
      [preview-table
       :query-results @results-preview]
      [:button.btn.btn-primary.btn-raised.view-results

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -210,6 +210,12 @@
    (get-in current-mine [:possible-values path])))
 
 (reg-sub
+ :current-class-keys
+ :<- [:current-mine]
+ (fn [current-mine]
+   (:class-keys current-mine)))
+
+(reg-sub
  :invalid-token?
  (fn [db]
    (get db :invalid-token?)))

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -207,7 +207,7 @@
  :current-possible-values
  :<- [:current-mine]
  (fn [current-mine [_ path]]
-   (get-in current-mine [:possible-values path])))
+   (sort (get-in current-mine [:possible-values path]))))
 
 (reg-sub
  :invalid-token?

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -207,7 +207,7 @@
  :current-possible-values
  :<- [:current-mine]
  (fn [current-mine [_ path]]
-   (sort (get-in current-mine [:possible-values path]))))
+   (get-in current-mine [:possible-values path])))
 
 (reg-sub
  :invalid-token?


### PR DESCRIPTION
- Sort dropdown constraints alphabetically
- Support `java.util.Date` constraints using [calendar component](https://github.com/gpbl/react-day-picker)
- Remove empty classes from model, and do not display them in querybuilder
- Use free text for integer constraints (it would previously give you a dropdown)
- Fix constraint codes being jumped over (ie. from A -> C, skipping B)
- Less intrusive loader when fetching preview in querybuilder and templates
- Use a [searchable dropdown component](https://github.com/JedWatson/react-select) for dropdown and group constraints
- Improve styling and feedback of list-dropdown (for IN and NOT IN constraint operators)
- Disallow adding constraints to classes without class keys in querybuilder (this is not possible in JSP)
- Show mine logo in navbar and login page
- Improve mine switcher UI

Just test the obvious things and review the diffs.

Use `BLUEGENES_DEFAULT_SERVICE_ROOT="https://test.intermine.org/covidmine" lein prod` for a suitable test mine.