### PR TITLE
Tool improvements and native viz support

### DIFF
--- a/less/components/enrichment.less
+++ b/less/components/enrichment.less
@@ -1,6 +1,7 @@
 @import "../variables";
 
 .enrichment {
+    margin-top: @spacer*1.5;
     font-size: 0.9em;
 
     a {

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -63,12 +63,4 @@
             align-items: baseline;
         }
     }
-
-    .viz {
-        margin-top: @spacer*2;
-
-        .vega-embed {
-            width: 100%;
-        }
-    }
 }

--- a/less/components/results.less
+++ b/less/components/results.less
@@ -63,4 +63,12 @@
             align-items: baseline;
         }
     }
+
+    .viz {
+        margin-top: @spacer*2;
+
+        .vega-embed {
+            width: 100%;
+        }
+    }
 }

--- a/less/components/viz.less
+++ b/less/components/viz.less
@@ -1,0 +1,49 @@
+@import "../variables";
+
+.viz {
+    // Without setting min-height this high, the window will scroll to the top
+    // when changing input to vega-lite although you never see an empty viz.
+    min-height: 600px;
+    margin-top: @spacer*2;
+
+    .title-group {
+        display: flex;
+        margin-bottom: @spacer;
+        align-items: center;
+        justify-content: space-between;
+
+        .subtitle {
+            font-size: 12px;
+            text-align: right;
+            font-style: oblique;
+        }
+    }
+
+    .control-group {
+        display: flex;
+        justify-content: space-evenly;
+    }
+
+    .toggle-group,
+    .number-input {
+        label {
+            font-size: 14px;
+            margin-left: @spacer/2;
+            margin-right: @spacer/2;
+        }
+    }
+
+    .number-input {
+        input {
+            display: inline-block;
+            height: 30px;
+            width: 60px;
+            margin-top: 5px;
+            margin-bottom: 1px;
+        }
+    }
+
+    .vega-embed {
+        width: 100%;
+    }
+}

--- a/less/site.less
+++ b/less/site.less
@@ -22,6 +22,7 @@
 @import "components/ui/inputs";
 @import "components/calendar";
 @import "components/constraints";
+@import "components/viz";
 @import "layouts/input-group";
 @import "layouts/header";
 @import "developer";

--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,7 @@
                  [markdown-to-hiccup "0.6.2"]
                  [cljsjs/react-day-picker "7.3.0-1"]
                  [cljsjs/react-select "2.4.4-0"]
+                 [metasoarous/oz "1.6.0-alpha6"]
 
                  ; HTTP
                  [clj-http "3.10.0"]

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,6 @@
                  [markdown-to-hiccup "0.6.2"]
                  [cljsjs/react-day-picker "7.3.0-1"]
                  [cljsjs/react-select "2.4.4-0"]
-                 [metasoarous/oz "1.6.0-alpha6"]
 
                  ; HTTP
                  [clj-http "3.10.0"]
@@ -67,6 +66,10 @@
                  [clojusc/friend-oauth2 "0.2.0"]
                  [lambdaisland/uri "1.2.1"]
 
+                 ; Graphs
+                 [cljsjs/vega "5.9.0-0"]
+                 [cljsjs/vega-lite "4.0.2-0"]
+                 [cljsjs/vega-embed "6.0.0-0"]
 
                  ; Intermine Assets
                  [org.intermine/im-tables "0.9.0"]

--- a/src/cljs/bluegenes/components/tools/effects.cljs
+++ b/src/cljs/bluegenes/components/tools/effects.cljs
@@ -1,0 +1,103 @@
+(ns bluegenes.components.tools.effects
+  (:require [re-frame.core :as rf :refer [dispatch reg-fx]]
+            [oops.core :refer [ocall+ oset!]]
+            [bluegenes.components.tools.events :as events]
+            [bluegenes.route :as route]
+            [clojure.string :as str]))
+
+(defmulti navigate
+  "Can be used from JS like this:
+      navigate('report', {type: 'Gene', id: 1018204}, 'humanmine');
+      navigate('query', myQueryObj, 'flymine');
+  Note that the third argument specifying the mine namespace is optional."
+  (fn [target data mine] (keyword target)))
+
+(defmethod navigate :report [_ report-data mine]
+  (let [{:keys [type id]} (js->clj report-data :keywordize-keys true)
+        source (keyword mine)]
+    (dispatch [::route/navigate ::route/report {:type type, :id id, :mine source}])))
+
+(defmethod navigate :query [_ query-data mine]
+  (let [query (js->clj query-data :keywordize-keys true)
+        source (keyword mine)]
+    (dispatch [::events/navigate-query query source])))
+
+(defn navigate!
+  "JS can't call `navigate` if we pass it the multimethod directly, so wrap it!"
+  [target data mine]
+  (navigate target data mine))
+
+(defn run-script!
+  "Executes a tool-api compliant main method to initialise a tool"
+  [tool tool-id & {:keys [service entity]}]
+  ;;the default method signature is
+  ;;package-name(el, service, package, state, config, navigate)
+  (let [el (.getElementById js/document tool-id)
+        ;; We are passing the model as well here in `service`, which is quite
+        ;; large, but could probably be useful?
+        service (clj->js service)
+        package (clj->js entity)
+        config (clj->js (:config tool))
+        main (str (get-in tool [:names :cljs]) ".main")]
+    (ocall+ js/window main el service package nil config navigate!)))
+
+(defn fetch-script!
+  ;; inspired by https://stackoverflow.com/a/31374433/1542891
+  "Dynamically inserts the tool api script into the head of the document.
+  If the script element is already present, re-run the tool's main function."
+  [tool tool-id & {:keys [service entity]}]
+  (let [script-id (str "script-" tool-id)
+        script-elem (.getElementById js/document script-id)]
+    ;; Script has been loaded before; re-run the main function.
+    (when script-elem
+      (run-script! tool tool-id :service service :entity entity))
+    ;; Do not add the script tag if it's already there.
+    (when-not script-elem
+      (let [script-tag (.createElement js/document "script")
+            head (aget (.getElementsByTagName js/document "head") 0)
+            tool-path (get-in tool [:config :files :js])]
+        (when-not tool-path
+          (.error js/console "%cNo script path provided for %s" "background:#ccc;border-bottom:solid 3px indianred; border-radius:2px;" (get-in tool [:names :human])))
+        (when tool-path
+          (oset! script-tag "id" script-id)
+          ;;fetch script from bluegenes-tool-store backend
+          (oset! script-tag "src" (str "/tools/" (get-in tool [:names :npm]) "/" tool-path))
+          ;;run-script will automatically be triggered when the script loads
+          (oset! script-tag "onload" #(run-script! tool tool-id
+                                                   :service service
+                                                   :entity entity))
+          ;;append script to dom
+          (.appendChild head script-tag))))))
+
+(defn fetch-styles!
+  "If the tool api script has a stylesheet as well, load it and insert into the doc"
+  [tool tool-id]
+  (let [style-id (str "style-" tool-id)
+        style-elem (.getElementById js/document style-id)]
+    ;; Do not add the style tag if it's already there.
+    (when-not style-elem
+      (let [style-tag (.createElement js/document "link")
+            head (aget (.getElementsByTagName js/document "head") 0)
+            style-path (get-in tool [:config :files :css])]
+        (when style-path
+          ;;fetch stylesheet and set some properties
+          (oset! style-tag "id" style-id)
+          (oset! style-tag "href" (str "/tools/" (get-in tool [:names :npm]) "/" style-path))
+          (oset! style-tag "type" "text/css")
+          (oset! style-tag "rel" "stylesheet")
+          ;;append to dom
+          (.appendChild head style-tag))))))
+
+;; This effect should be used to invoke the above functions. It can be run
+;; both when initially loading the tools and when the input data has changed,
+;; to pass the new entity to the tools (eg. opening a different report or
+;; results page, or modifying the contents of the result page's im-table).
+;; In the latter case, it will merely call the tool's main function.
+(reg-fx
+ :load-tools
+ (fn [{:keys [tools service entity]}]
+   (doseq [tool tools]
+     (let [{{:keys [human cljs npm]} :names} tool
+           tool-id (or cljs npm (str/replace human " " ""))]
+       (fetch-script! tool tool-id :service service :entity entity)
+       (fetch-styles! tool tool-id)))))

--- a/src/cljs/bluegenes/components/tools/effects.cljs
+++ b/src/cljs/bluegenes/components/tools/effects.cljs
@@ -40,7 +40,12 @@
         package (clj->js entity)
         config (clj->js (:config tool))
         main (str (get-in tool [:names :cljs]) ".main")]
-    (ocall+ js/window main el service package nil config navigate!)))
+    ;; If we don't wrap in a try-catch, errors thrown from tools can cause
+    ;; Bluegenes to halt execution.
+    (try
+      (ocall+ js/window main el service package nil config navigate!)
+      (catch js/Error e
+        (.error js/console e)))))
 
 (defn fetch-script!
   ;; inspired by https://stackoverflow.com/a/31374433/1542891

--- a/src/cljs/bluegenes/components/tools/effects.cljs
+++ b/src/cljs/bluegenes/components/tools/effects.cljs
@@ -114,7 +114,7 @@
    (doseq [tool tools]
      ;; `entity` is nil if tool is not suitable to be displayed.
      (when-let [entity (suitable-entities
-                         (get-in service [:model :classes]) entities (:config tool))]
+                        (get-in service [:model :classes]) entities (:config tool))]
        (if-let [tool-id (get-in tool [:names :cljs])]
          (do (fetch-script! tool tool-id :service service :entity entity)
              (fetch-styles! tool tool-id))

--- a/src/cljs/bluegenes/components/tools/events.cljs
+++ b/src/cljs/bluegenes/components/tools/events.cljs
@@ -61,8 +61,19 @@
    (let [tools    (get-in db [:tools :installed])
          service  (get-in db [:mines (:current-mine db) :service])
          entities (get-in db [:tools :entities])]
-     (if (empty? tools)
-       {}
-       {:load-suitable-tools {:tools tools
+     (cond
+       ;; Tools aren't ready yet.
+       (nil? tools)
+       {:retry {:event [::load-tools]
+                :timeout 1000}}
+       ;; We don't have any tools.
+       (empty? tools)
+       {:retry {:event [::load-tools]
+                :success? true}}
+       ;; We do have tools!
+       :else
+       {:retry {:event [::load-tools]
+                :success? true}
+        :load-suitable-tools {:tools tools
                               :service service
                               :entities entities}}))))

--- a/src/cljs/bluegenes/components/tools/events.cljs
+++ b/src/cljs/bluegenes/components/tools/events.cljs
@@ -1,7 +1,6 @@
 (ns bluegenes.components.tools.events
   (:require [re-frame.core :as re-frame :refer [reg-event-db reg-event-fx reg-fx dispatch subscribe]]
-            [bluegenes.effects :as fx]
-            [bluegenes.utils :refer [suitable-config?]]))
+            [bluegenes.effects :as fx]))
 
 (reg-event-fx
  ::fetch-tools
@@ -57,14 +56,13 @@
    (assoc-in db [:tools :path] path)))
 
 (reg-event-fx
- ::load-tools-for-entity
- (fn [{db :db} [_ entity]]
-   (let [tools   (get-in db [:tools :installed])
-         service (get-in db [:mines (:current-mine db) :service])
-         model   (get-in service [:model :classes])
-         suitable-tools (filter #(suitable-config? model entity %) tools)]
-     (if (empty? suitable-tools)
+ ::load-tools
+ (fn [{db :db} [_]]
+   (let [tools    (get-in db [:tools :installed])
+         service  (get-in db [:mines (:current-mine db) :service])
+         entities (get-in db [:tools :entities])]
+     (if (empty? tools)
        {}
-       {:load-tools {:tools suitable-tools
-                     :service service
-                     :entity entity}}))))
+       {:load-suitable-tools {:tools tools
+                              :service service
+                              :entities entities}}))))

--- a/src/cljs/bluegenes/components/tools/subs.cljs
+++ b/src/cljs/bluegenes/components/tools/subs.cljs
@@ -39,4 +39,4 @@
  :<- [::entities]
  :<- [:model]
  (fn [[tools entities model]]
-   (filter #(suitable-entities model entities %) (map :config tools))))
+   (filter #(suitable-entities model entities (:config %)) tools)))

--- a/src/cljs/bluegenes/components/tools/subs.cljs
+++ b/src/cljs/bluegenes/components/tools/subs.cljs
@@ -1,5 +1,6 @@
 (ns bluegenes.components.tools.subs
-  (:require [re-frame.core :refer [reg-sub]]))
+  (:require [re-frame.core :refer [reg-sub]]
+            [bluegenes.utils :refer [suitable-config?]]))
 
 (reg-sub
  ::entity
@@ -33,9 +34,4 @@
  :<- [::entity]
  :<- [:model]
  (fn [[tools entity model]]
-   (when-let [{:keys [format class]} entity]
-     (filter (fn [{{:keys [accepts classes depends]} :config :as _tool}]
-               (and (contains? (set accepts) format)
-                    (contains? (set classes) class)
-                    (every? #(contains? model %) (map keyword depends))))
-             tools))))
+   (filter #(suitable-config? model entity %) tools)))

--- a/src/cljs/bluegenes/components/tools/subs.cljs
+++ b/src/cljs/bluegenes/components/tools/subs.cljs
@@ -1,11 +1,16 @@
 (ns bluegenes.components.tools.subs
   (:require [re-frame.core :refer [reg-sub]]
-            [bluegenes.utils :refer [suitable-config?]]))
+            [bluegenes.utils :refer [suitable-entities]]))
 
 (reg-sub
  ::entity
  (fn [db]
    (get-in db [:tools :entity])))
+
+(reg-sub
+ ::entities
+ (fn [db]
+   (get-in db [:tools :entities])))
 
 (reg-sub
  ::installed-tools
@@ -31,7 +36,7 @@
 (reg-sub
  ::suitable-tools
  :<- [::installed-tools]
- :<- [::entity]
+ :<- [::entities]
  :<- [:model]
- (fn [[tools entity model]]
-   (filter #(suitable-config? model entity %) tools)))
+ (fn [[tools entities model]]
+   (filter #(suitable-entities model entities %) (map :config tools))))

--- a/src/cljs/bluegenes/components/tools/views.cljs
+++ b/src/cljs/bluegenes/components/tools/views.cljs
@@ -1,98 +1,10 @@
 (ns bluegenes.components.tools.views
   (:require [re-frame.core :refer [subscribe dispatch]]
-            [oops.core :refer [ocall+ oapply oget oget+ oset!]]
-            [bluegenes.components.tools.events :as events]
-            [bluegenes.components.tools.subs :as subs]
-            [bluegenes.route :as route]))
+            [bluegenes.components.tools.subs :as subs]))
 
-;;fixes the inability to iterate over html vector-like things
-(extend-type js/HTMLCollection
-  ISeqable
-  (-seq [array] (array-seq array 0)))
-
-(defmulti navigate
-  "Can be used from JS like this:
-      navigate('report', {type: 'Gene', id: 1018204}, 'humanmine');
-      navigate('query', myQueryObj, 'flymine');
-  Note that the third argument specifying the mine namespace is optional."
-  (fn [target data mine] (keyword target)))
-
-(defmethod navigate :report [_ report-data mine]
-  (let [{:keys [type id]} (js->clj report-data :keywordize-keys true)
-        source (keyword mine)]
-    (dispatch [::route/navigate ::route/report {:type type, :id id, :mine source}])))
-
-(defmethod navigate :query [_ query-data mine]
-  (let [query (js->clj query-data :keywordize-keys true)
-        source (or (keyword mine)
-                   @(subscribe [:current-mine-name]))]
-    (dispatch [::events/navigate-query query source])))
-
-(defn navigate_
-  "JS can't call `navigate` if we pass it the multimethod directly, so wrap it!"
-  [target data mine]
-  (navigate target data mine))
-
-(defn run-script
-  "Executes a tool-api compliant main method to initialise a tool"
-  [tool tool-id]
-  ;;the default method signature is
-  ;;package-name(el, service, package, state, config)
-  (let [el (.getElementById js/document tool-id)
-        service (clj->js (:service @(subscribe [:current-mine])))
-        package (clj->js @(subscribe [::subs/entity]))
-        config (clj->js (:config tool))
-        main (str (get-in tool [:names :cljs]) ".main")]
-    (ocall+ js/window main el service package nil config navigate_)))
-
-(defn fetch-script
-  ;; inspired by https://stackoverflow.com/a/31374433/1542891
-  ;; I don't much like fetching the script in the view, but given
-  ;; that this is heavy dom manipulation it seems necessary.
-  ;; TODO: could active scripts in appdb be dereferenced and added to
-  ;; the head automatically? That might be better if possible.
-  "Dynamically inserts the tool api script into the head of the document"
-  [tool tool-id]
-  (let [script-tag (.createElement js/document "script")
-        head (first (.getElementsByTagName js/document "head"))
-        tool-path (get-in tool [:config :files :js])]
-    (if tool-path
-      (do
-        ;;fetch script from npm's node_modules directory
-        (oset! script-tag "src" (str "/tools/" (get-in tool [:names :npm]) "/" tool-path))
-        ;;run-script will automatically be triggered when the script loads
-        (oset! script-tag "onload" #(run-script tool tool-id))
-        ;;append script to dom
-        (.appendChild head script-tag))
-      ;; there must be a script tag. If there isn't, console error.
-      (.error js/console "%cNo script path provided for %s" "background:#ccc;border-bottom:solid 3px indianred; border-radius:2px;" (get-in tool [:names :human])))))
-
-(defn fetch-styles
-  "If the tool api script has a stylesheet as well, load it and insert into the doc"
-  [tool]
-  (let [style-tag (.createElement js/document "link")
-        head (first (.getElementsByTagName js/document "head"))
-        style-path (get-in tool [:config :files :css])]
-    (cond style-path
-    ;;fetch stylesheet and set some properties
-          (do (oset! style-tag "href" (str "/tools/" (get-in tool [:names :npm]) "/" style-path))
-              (oset! style-tag "type" "text/css")
-              (oset! style-tag "rel" "stylesheet")
-    ;;append to dom
-              (.appendChild head style-tag)))))
-
-(defn main
-  "Initialise all the tools on the page"
-  []
-  (let [toolses           (subscribe [::subs/suitable-tools])]
-    (.log js/console "%c@toolses" "color:mediumorchid;font-weight:bold;" (clj->js @toolses))
-    (into [:div.tools]
-          (map
-           (fn [tool]
-             (let [tool-id (gensym (get-in tool [:config :toolName :cljs]))]
-               (fetch-script tool tool-id)
-               (fetch-styles tool)
-               [:div.tool {:class (get-in tool [:names :cljs])}
-                [:h3 (get-in tool [:names :human])]
-                [:div {:id tool-id}]]))
-           @toolses))))
+(defn main []
+  (into [:div.tools]
+        (for [{{:keys [cljs human]} :names} @(subscribe [::subs/suitable-tools])]
+          [:div.tool {:class cljs}
+           [:h3 human]
+           [:div {:id cljs}]])))

--- a/src/cljs/bluegenes/components/tools/views.cljs
+++ b/src/cljs/bluegenes/components/tools/views.cljs
@@ -3,8 +3,9 @@
             [bluegenes.components.tools.subs :as subs]))
 
 (defn main []
-  (into [:div.tools]
-        (for [{{:keys [cljs human]} :names} @(subscribe [::subs/suitable-tools])]
-          [:div.tool {:class cljs}
-           [:h3 human]
-           [:div {:id cljs}]])))
+  (let [suitable-tools @(subscribe [::subs/suitable-tools])]
+    (into [:div.tools]
+          (for [{{:keys [cljs human]} :names} suitable-tools]
+            [:div.tool {:class cljs}
+             [:h3 human]
+             [:div {:id cljs}]]))))

--- a/src/cljs/bluegenes/components/viz/cases.cljs
+++ b/src/cljs/bluegenes/components/viz/cases.cljs
@@ -1,9 +1,8 @@
 (ns bluegenes.components.viz.cases
-  (:require [re-frame.core :refer [dispatch subscribe]]
-            [reagent.core :as r]
+  (:require [reagent.core :as r]
             [oops.core :refer [oget]]
             [goog.string :refer [parseInt]]
-            [oz.core :refer [vega-lite]]))
+            [bluegenes.components.viz.common :refer [vega-lite]]))
 
 (def config
   {:accepts ["ids"]

--- a/src/cljs/bluegenes/components/viz/cases.cljs
+++ b/src/cljs/bluegenes/components/viz/cases.cljs
@@ -5,7 +5,7 @@
             [goog.string :refer [parseInt]]
             [oz.core :refer [vega-lite]]))
 
-(defn query [ids]
+(defn query [{:keys [Cases]}]
   {:from "Cases"
    :select ["date"
             "totalConfirmed"
@@ -16,7 +16,7 @@
             "geoLocation.state"]
    :where [{:path "Cases.id"
             :op "ONE OF"
-            :values ids}]})
+            :values Cases}]})
 
 (defn states-as-countries
   "Convert countries with states to be separate countries with the state in

--- a/src/cljs/bluegenes/components/viz/cases.cljs
+++ b/src/cljs/bluegenes/components/viz/cases.cljs
@@ -42,7 +42,6 @@
                   state (assoc-in [:geoLocation :country]
                                   (str country " (" state ")"))))))))
 
-
 (defn top-x-countries
   "Filters away all but the top `x` countries with the highest return value
   for `keyfn`."
@@ -151,7 +150,7 @@
                       ;; undefined behaviour.
                       (let [y-field (name @!y-field)
                             y (str "datum." y-field)]
-                        {:transform [{:calculate (str "if ("y"<1, 1, "y")")
+                        {:transform [{:calculate (str "if (" y "<1, 1, " y ")")
                                       :as y-field}]})))
                    {:width "container"
                     :mark {:type "bar" :tooltip true}
@@ -185,8 +184,8 @@
                                  (= @!bin-scale :log)
                                  (into (let [x-field (name @!y-field)
                                              x (str "datum." x-field)]
-                                         [{:filter (str x">0")}
-                                          {:calculate (str "log("x")/log(10)")
+                                         [{:filter (str x ">0")}
+                                          {:calculate (str "log(" x ")/log(10)")
                                            :as "log_x"}
                                           {:bin {:binned true :step 1} :field "log_x" :as "bin_log_x"}
                                           {:calculate "pow(10, datum.bin_log_x)"

--- a/src/cljs/bluegenes/components/viz/cases.cljs
+++ b/src/cljs/bluegenes/components/viz/cases.cljs
@@ -49,7 +49,6 @@
   [records x keyfn]
   (let [top-x (->> records
                    (group-by (comp :country :geoLocation))
-                   (#(dissoc % "World"))
                    (map (juxt key
                               (comp #(reduce + %)
                                     #(map keyfn %)

--- a/src/cljs/bluegenes/components/viz/cases.cljs
+++ b/src/cljs/bluegenes/components/viz/cases.cljs
@@ -99,7 +99,7 @@
         !bin-scale (r/atom :linear)
         !y-field (r/atom :totalConfirmed)]
     (fn [results]
-      [:div.container
+      [:div
        [:h4 (str "Showing top " @!top-x-count " countries with highest cases: " (name @!y-field))]
        [:div {:style {:display "flex"
                       :justify-content "space-evenly"}}
@@ -130,8 +130,10 @@
         {:data {:values (-> results
                             (states-as-countries)
                             (top-x-countries @!top-x-count @!y-field))}
+         :autosize {:type "fit-x"
+                    :contains "padding"}
          :vconcat [(merge
-                    {:width 700
+                    {:width "container"
                      :mark {:type (name @!mark-type) :tooltip true}
                      :encoding {:x {:field "date"
                                     :type "temporal"}
@@ -151,7 +153,7 @@
                             y (str "datum." y-field)]
                         {:transform [{:calculate (str "if ("y"<1, 1, "y")")
                                       :as y-field}]})))
-                   {:width 700
+                   {:width "container"
                     :mark {:type "bar" :tooltip true}
                     ;; We could support log scaling on the histogram's Y axis,
                     ;; but we'd have to disable stacking countries for that and

--- a/src/cljs/bluegenes/components/viz/cases.cljs
+++ b/src/cljs/bluegenes/components/viz/cases.cljs
@@ -1,0 +1,195 @@
+(ns bluegenes.components.viz.cases
+  (:require [re-frame.core :refer [dispatch subscribe]]
+            [reagent.core :as r]
+            [oops.core :refer [oget]]
+            [goog.string :refer [parseInt]]
+            [oz.core :refer [vega-lite]]))
+
+(defn query [ids]
+  {:from "Cases"
+   :select ["date"
+            "totalConfirmed"
+            "totalDeaths"
+            "newConfirmed"
+            "newDeaths"
+            "geoLocation.country"
+            "geoLocation.state"]
+   :where [{:path "Cases.id"
+            :op "ONE OF"
+            :values ids}]})
+
+(defn states-as-countries
+  "Convert countries with states to be separate countries with the state in
+  parentheses. Also removes the converted countries' total entries."
+  [records]
+  (let [countries-with-states (->> records
+                                   (filter (comp :state :geoLocation))
+                                   (map (comp :country :geoLocation))
+                                   (set))]
+    (->> records
+         (remove (fn [{{:keys [country state]} :geoLocation}]
+                   (and (contains? countries-with-states country)
+                        (nil? state))))
+         (map (fn [{{:keys [country state]} :geoLocation :as m}]
+                (cond-> m
+                  state (assoc-in [:geoLocation :country]
+                                  (str country " (" state ")"))))))))
+
+
+(defn top-x-countries
+  "Filters away all but the top `x` countries with the highest return value
+  for `keyfn`."
+  [records x keyfn]
+  (let [top-x (->> records
+                   (group-by (comp :country :geoLocation))
+                   (#(dissoc % "World"))
+                   (map (juxt key
+                              (comp #(reduce + %)
+                                    #(map keyfn %)
+                                    val)))
+                   (sort-by second >)
+                   (take x)
+                   (map first)
+                   (set))]
+    (filter (comp top-x :country :geoLocation) records)))
+
+(defn log-ready
+  "Replaces zero or negative values under key `k` with 1,
+  to allow log scales to be used."
+  [records k]
+  (map (fn [m]
+         (update m k #(if (not (pos? %)) 1 %)))
+       records))
+
+(defn toggle-group [atom group-label props]
+  [:div.toggle-group
+   [:label {:style {:margin-left "0.5em"
+                    :margin-right "0.5em"}}
+    group-label]
+   (into [:div.btn-group]
+         (for [{:keys [label value active]} props]
+           [:button.btn.btn-default.btn-sm
+            {:type "button"
+             :class (when (or active (= @atom value))
+                      :active)
+             :on-click #(reset! atom value)}
+            (or label (name value))]))])
+
+(defn number-input [atom label]
+  [:div
+   [:label {:style {:margin-left "0.5em"
+                    :margin-right "0.5em"}}
+    label]
+   [:input.form-control
+    {:type "number"
+     :style {:height "30px" :width "80px" :display "inline-block"}
+     :on-change #(when-let [x (parseInt (oget % :target :value))]
+                   (when (pos? x)
+                     (reset! atom x)))
+     :value @atom}]])
+
+;; - tooltips in histogram not working anymore (after adding selection: brush)
+;; Suggestions:
+;; - setting whether states should be included with or without country total, or excluded
+;; - remove :style usage
+(defn viz [results]
+  (let [!top-x-count (r/atom 10)
+        !mark-type (r/atom :line)
+        !scale-type (r/atom :linear)
+        !bin-scale (r/atom :linear)
+        !y-field (r/atom :totalConfirmed)]
+    (fn [results]
+      [:div.container
+       [:h4 (str "Showing top " @!top-x-count " countries with highest cases: " (name @!y-field))]
+       [:div {:style {:display "flex"
+                      :justify-content "space-evenly"}}
+        [number-input !top-x-count
+         "Top"]
+        [toggle-group !mark-type
+         "Plot"
+         [{:value :line}
+          {:value :area}]]
+        [toggle-group !scale-type
+         "Y-axis"
+         (if (= @!mark-type :area)
+           ;; Log scaling doesn't work for area charts.
+           [{:value :linear :active true}]
+           [{:value :linear}
+            {:value :log}])]
+        [toggle-group !bin-scale
+         "Bins"
+         [{:value :linear}
+          {:value :log}]]
+        [toggle-group !y-field
+         "Value"
+         [{:value :totalConfirmed}
+          {:value :totalDeaths}
+          {:value :newConfirmed}
+          {:value :newDeaths}]]]
+       [vega-lite
+        {:data {:values (-> results
+                            (states-as-countries)
+                            (top-x-countries @!top-x-count @!y-field))}
+         :vconcat [(merge
+                    {:width 700
+                     :mark {:type (name @!mark-type) :tooltip true}
+                     :encoding {:x {:field "date"
+                                    :type "temporal"}
+                                :y (merge {:field (name @!y-field)
+                                           :type "quantitative"}
+                                          (when (and (= @!scale-type :log)
+                                                     (= @!mark-type :line))
+                                            {:scale {:type "log" :base 2}}))
+                                :color {:field "geoLocation.country"
+                                        :type "nominal"}}
+                     :selection {:brush {:encodings ["x"] :type "interval"}}}
+                    (when (= @!scale-type :log)
+                      ;; Replace zero and negative values with 1. In log scale,
+                      ;; 0 becomes negative infinity and negative values have
+                      ;; undefined behaviour.
+                      (let [y-field (name @!y-field)
+                            y (str "datum." y-field)]
+                        {:transform [{:calculate (str "if ("y"<1, 1, "y")")
+                                      :as y-field}]})))
+                   {:width 700
+                    :mark {:type "bar" :tooltip true}
+                    ;; We could support log scaling on the histogram's Y axis,
+                    ;; but we'd have to disable stacking countries for that and
+                    ;; the data may be faulty due to transform. Its usefulness
+                    ;; is also questionable when we support logarithmic binning.
+                    :encoding (if (= @!bin-scale :log)
+                                {:x {:field "x1"
+                                     :type "quantitative"
+                                     :scale {:type "log" :base 10}
+                                     :axis {:tickCount 5
+                                            :title (str (name @!y-field) " (log binned)")}}
+                                 :x2 {:field "x2"}
+                                 :y {:aggregate "count"
+                                     :type "quantitative"}
+                                 :color {:field "geoLocation.country"
+                                         :type "nominal"}}
+                                {:x {:field (name @!y-field)
+                                     :type "quantitative"
+                                     :bin true}
+                                 :y {:aggregate "count"
+                                     :type "quantitative"}
+                                 :color {:field "geoLocation.country"
+                                         :type "nominal"}})
+                    :transform (cond-> [{:filter {:selection "brush"}}]
+                                 (= @!bin-scale :log)
+                                 (into (let [x-field (name @!y-field)
+                                             x (str "datum." x-field)]
+                                         [{:filter (str x">0")}
+                                          {:calculate (str "log("x")/log(10)")
+                                           :as "log_x"}
+                                          {:bin {:binned true :step 1} :field "log_x" :as "bin_log_x"}
+                                          {:calculate "pow(10, datum.bin_log_x)"
+                                           :as "x1"}
+                                          {:calculate "pow(10, datum.bin_log_x_end)"
+                                           :as "x2"}])))}]}]])))
+
+(def config
+  {:accepts ["ids"]
+   :classes ["Cases"]
+   :depends ["Cases"]
+   :toolName {:human "Cases per-country plot and histogram"}})

--- a/src/cljs/bluegenes/components/viz/cases.cljs
+++ b/src/cljs/bluegenes/components/viz/cases.cljs
@@ -9,7 +9,8 @@
   {:accepts ["ids"]
    :classes ["Cases"]
    :depends ["Cases"]
-   :toolName {:human "Cases per-country plot and histogram"}})
+   :toolName {:human "Cases per-country plot and histogram"}
+   :version 2})
 
 (defn query [{{:keys [value]} :Cases}]
   {:from "Cases"

--- a/src/cljs/bluegenes/components/viz/cases.cljs
+++ b/src/cljs/bluegenes/components/viz/cases.cljs
@@ -5,7 +5,7 @@
             [goog.string :refer [parseInt]]
             [oz.core :refer [vega-lite]]))
 
-(defn query [{:keys [Cases]}]
+(defn query [{{:keys [value]} :Cases}]
   {:from "Cases"
    :select ["date"
             "totalConfirmed"
@@ -16,7 +16,7 @@
             "geoLocation.state"]
    :where [{:path "Cases.id"
             :op "ONE OF"
-            :values Cases}]})
+            :values value}]})
 
 (defn states-as-countries
   "Convert countries with states to be separate countries with the state in

--- a/src/cljs/bluegenes/components/viz/common.cljs
+++ b/src/cljs/bluegenes/components/viz/common.cljs
@@ -1,0 +1,54 @@
+(ns bluegenes.components.viz.common
+  (:require [reagent.core :as r]
+            [reagent.dom :as rd]))
+
+;; Taken from the oz project and adjusted to our usecase.
+;; https://github.com/metasoarous/oz/blob/master/src/cljs/oz/core.cljs
+
+;; An alternative way to update the data input which *could* result in better
+;; performance would be by using data streaming.
+;; https://vega.github.io/vega-lite/tutorials/streaming.html
+;; https://vega.github.io/vega/docs/api/view/#view_data
+;; We would have to give each viz a unique named data source, and save the
+;; delivered promise returned by vegaEmbed (probably in a regular atom).
+;; Then we're able to use `promiseResult.view.data(name, newData).run()` to only
+;; update the data (we can check in `:component-did-update` whether only the
+;; data changed) instead of unnecessarily re-running vegaEmbed.
+
+(defn ^:no-doc embed-vega
+  ([elem doc] (embed-vega elem doc {}))
+  ([elem doc opts]
+   (when doc
+     (let [doc (clj->js doc)
+           opts (merge {:renderer :canvas
+                        ;; Have to think about how we want the defaults here to behave
+                        :mode "vega-lite"}
+                       opts)]
+       (-> (js/vegaEmbed elem doc (clj->js opts))
+           (.catch (fn [err]
+                     (.warn js/console err))))))))
+
+(defn vega
+  "Reagent component that renders vega"
+  ([doc] (vega doc {}))
+  ([doc opts]
+   ;; Is this the right way to do this? So vega component behaves abstractly like a vega-lite potentially?
+   (let [opts (merge {:mode "vega"} opts)]
+     (r/create-class
+      {:display-name "vega"
+       :component-did-mount (fn [this]
+                              (embed-vega (rd/dom-node this) doc opts))
+       :component-did-update (fn [this [_ old-doc old-opts]]
+                               (let [[_ new-doc new-opts] (r/argv this)]
+                                 (when (or (not= old-doc new-doc)
+                                           (not= old-opts new-opts))
+                                   (embed-vega (rd/dom-node this) new-doc new-opts))))
+       :reagent-render (fn []
+                         [:div.viz])}))))
+
+(defn vega-lite
+  "Reagent component that renders vega-lite."
+  ([doc] (vega-lite doc {}))
+  ([doc opts]
+   ;; Which way should the merge go?
+   (vega doc (merge opts {:mode "vega-lite"}))))

--- a/src/cljs/bluegenes/components/viz/events.cljs
+++ b/src/cljs/bluegenes/components/viz/events.cljs
@@ -1,16 +1,17 @@
 (ns bluegenes.components.viz.events
   (:require [re-frame.core :refer [reg-event-db reg-event-fx reg-fx dispatch subscribe]]
-            [bluegenes.utils :refer [suitable-config?]]
+            [bluegenes.utils :refer [suitable-entities]]
             [imcljs.fetch :as fetch]
             [bluegenes.components.viz.views :refer [all-viz]]))
 
 (reg-event-fx
- :viz/run-queries-for-entity
- (fn [{db :db} [_ entity]]
-   (let [model (get-in db [:mines (:current-mine db) :service :model :classes])]
+ :viz/run-queries
+ (fn [{db :db} [_]]
+   (let [entities (get-in db [:tools :entities])
+         model (get-in db [:mines (:current-mine db) :service :model :classes])]
      {:dispatch-n (map (fn [{:keys [config query key]}]
-                         (when (suitable-config? model entity config)
-                           [:viz/run-query key (query (:value entity))]))
+                         (when-let [entity (suitable-entities model entities config)]
+                           [:viz/run-query key (query entity)]))
                        all-viz)})))
 
 (reg-event-fx

--- a/src/cljs/bluegenes/components/viz/events.cljs
+++ b/src/cljs/bluegenes/components/viz/events.cljs
@@ -1,0 +1,31 @@
+(ns bluegenes.components.viz.events
+  (:require [re-frame.core :refer [reg-event-db reg-event-fx reg-fx dispatch subscribe]]
+            [bluegenes.utils :refer [suitable-config?]]
+            [imcljs.fetch :as fetch]
+            [bluegenes.components.viz.views :refer [all-viz]]))
+
+(reg-event-fx
+ :viz/run-queries-for-entity
+ (fn [{db :db} [_ entity]]
+   (let [model (get-in db [:mines (:current-mine db) :service :model :classes])]
+     {:dispatch-n (map (fn [{:keys [config query key]}]
+                         (when (suitable-config? model entity config)
+                           [:viz/run-query key (query (:value entity))]))
+                       all-viz)})))
+
+(reg-event-fx
+ :viz/run-query
+ (fn [{db :db} [_ key query]]
+   (let [service (get-in db [:mines (:current-mine db) :service])]
+     {:im-chan {:chan (fetch/records service query)
+                :on-success [:viz/run-query-success key]}})))
+
+(reg-event-db
+ :viz/run-query-success
+ (fn [db [_ key response]]
+   (assoc-in db [:results :viz key] (:results response))))
+
+(reg-event-db
+ :viz/clear
+ (fn [db [_]]
+   (assoc-in db [:results :viz] nil)))

--- a/src/cljs/bluegenes/components/viz/subs.cljs
+++ b/src/cljs/bluegenes/components/viz/subs.cljs
@@ -1,0 +1,7 @@
+(ns bluegenes.components.viz.subs
+  (:require [re-frame.core :refer [reg-sub]]))
+
+(reg-sub
+ :viz/results
+ (fn [db [_]]
+   (get-in db [:results :viz])))

--- a/src/cljs/bluegenes/components/viz/views.cljs
+++ b/src/cljs/bluegenes/components/viz/views.cljs
@@ -1,8 +1,6 @@
 (ns bluegenes.components.viz.views
-  (:require [re-frame.core :refer [subscribe dispatch]]
-            [reagent.core :as r]
-            [bluegenes.components.viz.cases :as cases]
-            [oz.core :refer [vega-lite]]))
+  (:require [re-frame.core :refer [subscribe]]
+            [bluegenes.components.viz.cases :as cases]))
 
 (def all-viz [{:config cases/config
                :query cases/query

--- a/src/cljs/bluegenes/components/viz/views.cljs
+++ b/src/cljs/bluegenes/components/viz/views.cljs
@@ -11,8 +11,10 @@
 
 (defn main []
   (let [all-results @(subscribe [:viz/results])]
-    (into [:div.tools]
+    (into [:div.viz]
           (for [{:keys [viz key]} all-viz]
             (when-let [results (get all-results key)]
               ^{:key (name key)}
-              [viz results])))))
+              [:div.panel.panel-default
+               [:div.panel-body
+                [viz results]]])))))

--- a/src/cljs/bluegenes/components/viz/views.cljs
+++ b/src/cljs/bluegenes/components/viz/views.cljs
@@ -7,14 +7,16 @@
 (def all-viz [{:config cases/config
                :query cases/query
                :viz cases/viz
-               :key :cases}])
+               :key :cases
+               :package {:description "Developed for CovidMine. Shows a customizable plot and histogram for countries and timeline present in results."}}])
 
 (defn main []
   (let [all-results @(subscribe [:viz/results])]
-    (into [:div.viz]
+    (into [:div]
           (for [{:keys [viz key]} all-viz]
             (when-let [results (get all-results key)]
               ^{:key (name key)}
-              [:div.panel.panel-default
-               [:div.panel-body
-                [viz results]]])))))
+              [:div.viz
+               [:div.panel.panel-default
+                [:div.panel-body
+                 [viz results]]]])))))

--- a/src/cljs/bluegenes/components/viz/views.cljs
+++ b/src/cljs/bluegenes/components/viz/views.cljs
@@ -1,0 +1,18 @@
+(ns bluegenes.components.viz.views
+  (:require [re-frame.core :refer [subscribe dispatch]]
+            [reagent.core :as r]
+            [bluegenes.components.viz.cases :as cases]
+            [oz.core :refer [vega-lite]]))
+
+(def all-viz [{:config cases/config
+               :query cases/query
+               :viz cases/viz
+               :key :cases}])
+
+(defn main []
+  (let [all-results @(subscribe [:viz/results])]
+    (into [:div.tools]
+          (for [{:keys [viz key]} all-viz]
+            (when-let [results (get all-results key)]
+              ^{:key (name key)}
+              [viz results])))))

--- a/src/cljs/bluegenes/core.cljs
+++ b/src/cljs/bluegenes/core.cljs
@@ -13,6 +13,9 @@
             [cljsjs.react-transition-group]
             [cljsjs.react-day-picker]
             [cljsjs.react-select]
+            [cljsjs.vega]
+            [cljsjs.vega-lite]
+            [cljsjs.vega-embed]
             [oops.core :refer [ocall]]))
 
 ;(defn dev-setup []

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -17,6 +17,7 @@
             [bluegenes.pages.reportpage.events]
             [bluegenes.pages.querybuilder.events]
             [bluegenes.pages.profile.events]
+            [bluegenes.components.viz.events]
             [bluegenes.effects :refer [document-title]]
             [bluegenes.route :as route]
             [imcljs.fetch :as fetch]

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -19,6 +19,7 @@
             [bluegenes.pages.profile.events]
             [bluegenes.components.viz.events]
             [bluegenes.effects :refer [document-title]]
+            [bluegenes.components.tools.effects]
             [bluegenes.route :as route]
             [imcljs.fetch :as fetch]
             [imcljs.path :as im-path]

--- a/src/cljs/bluegenes/events/registry.cljs
+++ b/src/cljs/bluegenes/events/registry.cljs
@@ -2,13 +2,8 @@
   (:require [re-frame.core :refer [reg-event-fx dispatch]]
             [imcljs.fetch :as fetch]
             [clojure.string :as string]
-            [bluegenes.utils :refer [read-registry-mine]]))
-
-;; this is not crazy to hardcode. The consequences of a mine that is lower than
-;; the minimum version using bluegenes could potentially result in corrupt lists
-;; so it *should* be hard to change.
-;;https://github.com/intermine/intermine/issues/1482
-(def min-intermine-version 27)
+            [bluegenes.utils :refer [read-registry-mine]]
+            [bluegenes.version :as version]))
 
 (reg-event-fx
  ;; these are the intermines we'll allow users to switch to
@@ -50,7 +45,7 @@
  (fn [{db :db} [_ mines]]
    (let [;; they *were* in an array, but a map would be easier to reference mines
          registry (into {} (comp (filter #(>= (js/parseInt (:api_version %) 10)
-                                              min-intermine-version))
+                                              version/minimum-intermine))
                                  (filter #(compatible-protocol? (:url %)))
                                  (map (juxt (comp keyword :namespace) identity)))
                         mines)

--- a/src/cljs/bluegenes/pages/developer/tools.cljs
+++ b/src/cljs/bluegenes/pages/developer/tools.cljs
@@ -3,7 +3,8 @@
             [bluegenes.components.tools.subs :as tools-subs]
             [bluegenes.pages.developer.events :as events]
             [markdown-to-hiccup.core :as md]
-            [bluegenes.version :as version]))
+            [bluegenes.version :as version]
+            [bluegenes.components.viz.views :refer [all-viz]]))
 
 (defn action [func]
   (fn [e]
@@ -124,6 +125,23 @@
           "Install"]]]])
     @tools)))
 
+(defn native-viz-list
+  "Display all native visualizations integrated into BlueGenes."
+  [vizs]
+  (into [:div.tool-list]
+        (for [{{:keys [accepts classes depends version]} :config :as viz} vizs]
+          [:div.tool
+           [:h2 (get-in viz [:config :toolName :human])]
+           [:div.details
+            [tool-description (get-in viz [:package :description])]
+            [output-tool-version (or version 1)]
+            [output-tool-depends depends]
+            [output-tool-classes classes]
+            [output-tool-accepts accepts]]
+           [:div.tool-footer
+            [:div.tool-data
+             "Included with BlueGenes"]]])))
+
 (defn tool-store
   "Page structure for tool store UI"
   []
@@ -145,4 +163,8 @@
          [:button.btn.btn-primary.btn-raised
           {:on-click (action #(dispatch [::events/install-all-tools]))}
           "Install all tools"]])
-      [available-tool-list remaining-tools]]]))
+      [available-tool-list remaining-tools]
+      (when (seq all-viz)
+        [:div.info
+         [:h4 "Native visualizations"]])
+      [native-viz-list all-viz]]]))

--- a/src/cljs/bluegenes/pages/developer/tools.cljs
+++ b/src/cljs/bluegenes/pages/developer/tools.cljs
@@ -2,7 +2,8 @@
   (:require [re-frame.core :as re-frame :refer [dispatch subscribe]]
             [bluegenes.components.tools.subs :as tools-subs]
             [bluegenes.pages.developer.events :as events]
-            [markdown-to-hiccup.core :as md]))
+            [markdown-to-hiccup.core :as md]
+            [bluegenes.version :as version]))
 
 (defn action [func]
   (fn [e]
@@ -52,6 +53,20 @@
         (into [:<> (interpose " " (map #(vector :code %) unsupported))])
         ". However, it may be shown for other mines."]])))
 
+(defn output-tool-version
+  "Shows an alert if the version does not match this Bluegenes' tool API."
+  [version]
+  (let [supported? (= version version/tool-api)]
+    (when-not supported?
+      [:div.tool-alert
+       [:p "This tool is disabled due to using a different Tool API version than this BlueGenes instance. "
+        [:code (str "Tool: " version)]
+        " "
+        [:code (str "BlueGenes: " version/tool-api)]
+        (if (< version version/tool-api)
+          " We recommend updating the tool to the latest version."
+          " We recommend updating BlueGenes to the latest version.")]])))
+
 (defn tool-description
   [text]
   (when (not-empty text)
@@ -75,6 +90,7 @@
          [:div.tool-no-preview "No tool preview available"])
        [:div.details
         [tool-description (get-in tool [:package :description])]
+        [output-tool-version (get-in tool [:config :version] 1)]
         [output-tool-depends (get-in tool [:config :depends])]
         [output-tool-classes (get-in tool [:config :classes])]
         [output-tool-accepts (get-in tool [:config :accepts])]]

--- a/src/cljs/bluegenes/pages/mymine/views/mymine.cljs
+++ b/src/cljs/bluegenes/pages/mymine/views/mymine.cljs
@@ -8,7 +8,8 @@
             [bluegenes.pages.mymine.views.modals :as modals]
             [bluegenes.pages.mymine.views.contextmenu :as m]
             [bluegenes.route :as route]
-            [bluegenes.pages.mymine.views.organize :as organize])
+            [bluegenes.pages.mymine.views.organize :as organize]
+            [bluegenes.version :as version])
   (:import
    (goog.i18n NumberFormat)
    (goog.i18n.NumberFormat Format)))
@@ -95,7 +96,8 @@
             "Subtract " [:svg.icon.icon-venn-difference.venn [:use {:xlinkHref "#icon-venn-difference"}]]]]
           (let [no-login? (not @(subscribe [:bluegenes.subs.auth/authenticated?]))
                 no-lists? (empty? @(subscribe [:lists/authorized-lists]))
-                no-support? (< (first @(subscribe [:current-intermine-version])) 5)
+                no-support? (< (first @(subscribe [:current-intermine-version]))
+                               version/organize-support)
                 problem? (or no-lists? no-login? no-support?)]
             [:li.hidden-xs {:class (when problem? "disabled")}
              [:a (merge

--- a/src/cljs/bluegenes/pages/reportpage/events.cljs
+++ b/src/cljs/bluegenes/pages/reportpage/events.cljs
@@ -5,13 +5,15 @@
             [bluegenes.effects :refer [document-title]]
             [clojure.string :as string]))
 
-(reg-event-db
+(reg-event-fx
  :handle-report-summary
  [document-title]
- (fn [db [_ summary]]
-   (-> db
-       (assoc-in [:report :summary] summary)
-       (assoc :fetching-report? false))))
+ (fn [{db :db} [_ summary]]
+   {:db (-> db
+            (assoc-in [:report :summary] summary)
+            (assoc :fetching-report? false))
+    :dispatch-n [[:viz/run-queries]
+                 [::tools/load-tools]]}))
 
 (reg-event-fx
  :fetch-report
@@ -56,7 +58,7 @@
      {:db (-> db
               (assoc :fetching-report? true)
               (dissoc :report)
-              (assoc-in [:tools :entity] entity))
+              (assoc-in [:tools :entities (keyword type)] entity))
       :dispatch-n [[::tools/fetch-tools]
                    [:fetch-report (keyword mine) type id]
                    (when (= type "Gene")

--- a/src/cljs/bluegenes/pages/reportpage/views.cljs
+++ b/src/cljs/bluegenes/pages/reportpage/views.cljs
@@ -9,7 +9,8 @@
             [bluegenes.pages.reportpage.subs :as subs]
             [im-tables.views.core :as im-table]
             [imcljs.path :as im-path]
-            [bluegenes.route :as route]))
+            [bluegenes.route :as route]
+            [bluegenes.components.viz.views :as viz]))
 
 (defn tbl [{:keys [loc]}]
   (let [data (subscribe [::subs/a-table loc])]
@@ -108,6 +109,7 @@
                [summary/main (:summary @report)]
                (when (:summary @report)
                  [:div.report-body
+                  [viz/main]
                   [tools/main]
                   [collections-and-references service current-mine-name type id]
                   [templates-for-entity service current-mine-name id]])])]))])))

--- a/src/cljs/bluegenes/pages/results/events.cljs
+++ b/src/cljs/bluegenes/pages/results/events.cljs
@@ -183,7 +183,8 @@
                  :format "ids"
                  :value (reduce into results)}]
      {:db (assoc-in db [:tools :entities class] entity)
-      :dispatch [:viz/run-queries-for-entity entity]})))
+      :dispatch-n [[:viz/run-queries-for-entity entity]
+                   [::tools/load-tools-for-entity entity]]})))
 
 (reg-event-db
  :clear-ids-tool-entity

--- a/src/cljs/bluegenes/pages/results/events.cljs
+++ b/src/cljs/bluegenes/pages/results/events.cljs
@@ -80,6 +80,8 @@
            ;; Our route runs `:results/load-history`.
      (assoc :dispatch [::route/navigate ::route/list {:title (:title value)}]))))
 
+(def im-table-location [:results :table])
+
 ; Load one package at a particular index from the list analysis history collection
 (reg-event-fx
  :results/load-history
@@ -109,11 +111,12 @@
                     ; Clear the enrichment results before loading any new ones
                     :enrichment-results nil)
         :dispatch-n [;; Fetch IDs to build tool entity, and then our tools.
-                     [:fetch-ids-tool-entity]
+                     [:fetch-ids-tool-entities]
+                     [::tools/fetch-tools]
                      ; Fire the enrichment event (see the TODO above)
                      [:enrichment/enrich]
                      [:im-tables/load
-                      [:results :table]
+                      im-table-location
                       {:service (merge service {:summary-fields summary-fields})
                        :query value
                        :settings {:pagination {:limit 10}
@@ -125,27 +128,67 @@
                                                               :id objectId}))}}}]]}))))
 
 (reg-event-fx
- :fetch-ids-tool-entity
+ :results/listen-im-table-changes
+ (fn [{db :db} [_]]
+   {:forward-events {:register :results-page-im-table-listener
+                     ;; These fire whenever the query in im-tables is changed,
+                     ;; and runs successfully.
+                     :events #{:main/replace-query-response
+                               :main/merge-query-response}
+                     :dispatch-to [:results/update-tool-entities]}}))
+
+(reg-event-fx
+ :results/unlisten-im-table-changes
+ (fn [{db :db} [_]]
+   {:forward-events {:unregister :results-page-im-table-listener}}))
+
+(reg-event-fx
+ :results/update-tool-entities
+ (fn [{db :db} [_]]
+   (let [source (get-in db [:results :package :source])
+         model  (get-in db [:mines source :service :model])
+         ;; We have to reach into the im-table to get the updated query,
+         ;; as it's not passed via event handlers we can intercept.
+         query  (get-in db (conj im-table-location :query))]
+     ;; We wouldn't need to update db if we passed query-parts directly to the
+     ;; two events dispatched below (see TODO above).
+     {:db (update db :results assoc
+                  :query-parts (q/group-views-by-class model query))
+      :dispatch-n [[:fetch-ids-tool-entities]
+                   [:enrichment/enrich]]})))
+
+(reg-event-fx
+ :fetch-ids-tool-entities
  (fn [{db :db} _]
-   (let [{:keys [source value]} (get-in db [:results :package])
-         service (get-in db [:mines source :service])
-         query (assoc value :select ["Gene.id"])]
+   (let [{:keys [source]} (get-in db [:results :package])
+         query-parts (get-in db [:results :query-parts])]
+     {:dispatch-n (reduce (fn [events [class parts]]
+                            (into events (map (fn [{:keys [query]}]
+                                                [:fetch-ids-tool-entity class source query])
+                                              parts)))
+                          []
+                          query-parts)})))
+
+(reg-event-fx
+ :fetch-ids-tool-entity
+ (fn [{db :db} [_ class source query]]
+   (let [service (get-in db [:mines source :service])]
      {:im-chan {:chan (fetch/rows service query)
-                :on-success [:success-fetch-ids-tool-entity]}})))
+                :on-success [:success-fetch-ids-tool-entity class]}})))
 
 (reg-event-fx
  :success-fetch-ids-tool-entity
- (fn [{db :db} [_ {:keys [rootClass results]}]]
-   (let [entity {:class rootClass
+ (fn [{db :db} [_ class {:keys [results]}]]
+   (let [entity {:class (name class)
                  :format "ids"
                  :value (reduce into results)}]
-     {:db (assoc-in db [:tools :entity] entity)
-      :dispatch [::tools/fetch-tools]})))
+     {:db (assoc-in db [:tools :entities class] entity)
+      :dispatch [:viz/run-queries-for-entity entity]})))
 
 (reg-event-db
  :clear-ids-tool-entity
  (fn [db]
-   (assoc-in db [:tools :entity] nil)))
+   (update db :tools dissoc :entity :entities)))
 
 (reg-event-fx
  :fetch-enrichment-ids-from-query

--- a/src/cljs/bluegenes/pages/results/views.cljs
+++ b/src/cljs/bluegenes/pages/results/views.cljs
@@ -13,7 +13,8 @@
             [cljs-time.format :as time-format]
             [cljs-time.coerce :as time-coerce]
             [bluegenes.route :as route]
-            [bluegenes.components.tools.views :as tools]))
+            [bluegenes.components.tools.views :as tools]
+            [bluegenes.components.viz.views :as viz]))
 
 (def custom-time-formatter (time-format/formatter "dd MMM, yy HH:mm"))
 
@@ -120,9 +121,9 @@
           [:div.container-fluid.results
            {:style {:width "100%"}}
            [:div.row
-            [:div.col-sm-2
+            [:div.col-sm-3.col-lg-2
              [query-history]]
-            [:div.col-sm-7
+            [:div.col-sm-9.col-lg-7
              [:div
               {:style {:background-color "white"}}
               [tables/main [:results :table]]
@@ -130,6 +131,7 @@
                 ;; Only show when results are for a list, not a query.
                 ;; And only when the user is authorized to edit it.
                 [description-box name description])]
+             [viz/main]
              [:div
               [tools/main]]]
             [:div.col-sm-3

--- a/src/cljs/bluegenes/pages/results/views.cljs
+++ b/src/cljs/bluegenes/pages/results/views.cljs
@@ -122,7 +122,9 @@
            {:style {:width "100%"}}
            [:div.row
             [:div.col-sm-3.col-lg-2
-             [query-history]]
+             [query-history]
+             [:div.hidden-lg
+              [enrichment/enrich]]]
             [:div.col-sm-9.col-lg-7
              [:div
               {:style {:background-color "white"}}
@@ -134,7 +136,7 @@
              [viz/main]
              [:div
               [tools/main]]]
-            [:div.col-sm-3
+            [:div.col-sm-3.visible-lg-block
              [enrichment/enrich]]]
            #_[:div.results-and-enrichment
               [:div.col-md-8.col-sm-12.panel]

--- a/src/cljs/bluegenes/route.cljs
+++ b/src/cljs/bluegenes/route.cljs
@@ -198,9 +198,13 @@
                  ;; results and tools once they're ready.
                  (dispatch [:results/clear])
                  (dispatch [:clear-ids-tool-entity])
+                 (dispatch [:viz/clear])
                  (dispatch [:set-active-panel :results-panel
                             nil
-                            [::view-list title]]))}]}]
+                            [::view-list title]])
+                 (dispatch [:results/listen-im-table-changes]))
+        :stop (fn []
+                (dispatch [:results/unlisten-im-table-changes]))}]}]
     ["/regions"
      {:name ::regions
       :controllers

--- a/src/cljs/bluegenes/route.cljs
+++ b/src/cljs/bluegenes/route.cljs
@@ -218,6 +218,8 @@
       :controllers
       [{:parameters {:path [:mine :type :id]}
         :start (fn [{{:keys [mine type id]} :path}]
+                 (dispatch [:clear-ids-tool-entity])
+                 (dispatch [:viz/clear])
                  (dispatch [:set-active-panel :reportpage-panel
                             {:type type, :id id, :format "id", :mine mine}
                             [:load-report mine type id]]))}]}]]])

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -7,6 +7,7 @@
             [bluegenes.subs.auth]
             [bluegenes.components.idresolver.subs]
             [bluegenes.pages.profile.subs]
+            [bluegenes.components.viz.subs]
             [lambdaisland.uri :refer [uri]]))
 
 (reg-sub

--- a/src/cljs/bluegenes/utils.cljs
+++ b/src/cljs/bluegenes/utils.cljs
@@ -87,8 +87,7 @@
 
 (defn suitable-entities
   "Removes key-value pairs from an entities map which don't adhere to config.
-  Remaining value maps will be replaced with their `:value` key. May return
-  nil if no entity is suitable at all.
+  May return nil if no entity is suitable at all.
   1. Check that all model dependencies are present.
   2. Remove pairs which don't match accepted formats.
   3. Pick pairs that match classes (all when `*` wildcard is used)."
@@ -99,5 +98,4 @@
         (into {} (filter (comp (set accepts) :format val)) $)
         (if (some #{"*"} classes)
           $
-          (select-keys $ (map keyword classes)))
-        (into {} (map (juxt key (comp :value val))) $)))))
+          (select-keys $ (map keyword classes)))))))

--- a/src/cljs/bluegenes/utils.cljs
+++ b/src/cljs/bluegenes/utils.cljs
@@ -74,3 +74,13 @@
      :constraintLogic constraintLogic
      :joins joins
      :where where}))
+
+(defn suitable-config?
+  "Verifies a tool/viz `config` against a `model` and `entity`, returning
+  whether this tool/viz is suitable for displaying."
+  [model entity config]
+  (when-let [{:keys [format class]} entity]
+    (when-let [{:keys [accepts classes depends]} config]
+      (and (contains? (set accepts) format)
+           (contains? (set classes) class)
+           (every? #(contains? model %) (map keyword depends))))))

--- a/src/cljs/bluegenes/utils.cljs
+++ b/src/cljs/bluegenes/utils.cljs
@@ -87,7 +87,7 @@
 
 (defn suitable-entities
   "Removes key-value pairs from an entities map which don't adhere to config.
-  May return nil if no entity is suitable at all.
+  Will return nil if no entity is suitable at all.
   1. Check that all model dependencies are present.
   2. Remove pairs which don't match accepted formats.
   3. Pick pairs that match classes (all when `*` wildcard is used)."
@@ -98,4 +98,5 @@
         (into {} (filter (comp (set accepts) :format val)) $)
         (if (some #{"*"} classes)
           $
-          (select-keys $ (map keyword classes)))))))
+          (select-keys $ (map keyword classes)))
+        (not-empty $)))))

--- a/src/cljs/bluegenes/version.cljs
+++ b/src/cljs/bluegenes/version.cljs
@@ -1,0 +1,21 @@
+(ns bluegenes.version)
+
+;;;; Version numbers you *wouldn't* want to change (collected for reference).
+
+;; this is not crazy to hardcode. The consequences of a mine that is lower than
+;; the minimum version using bluegenes could potentially result in corrupt lists
+;; so it *should* be hard to change.
+;;https://github.com/intermine/intermine/issues/1482
+(def minimum-intermine 27)
+
+;; Prior to this major InterMine version, multiple TagManager's on the backend
+;; would cause updating and retrieving of tags set on lists to be buggy.
+(def organize-support 5)
+
+;;;; Version numbers you *might* want to change.
+
+;; This is the current Tool API version. Increment this when you're forced to
+;; perform a breaking change to the Tool API. All tools (as well as native viz
+;; in `bluegenes.components.viz`) will then need to be updated to support the
+;; new API and change their config version to the same number.
+(def tool-api 2)

--- a/test/cljs/bluegenes/effects_test.cljs
+++ b/test/cljs/bluegenes/effects_test.cljs
@@ -1,0 +1,21 @@
+(ns bluegenes.effects-test
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [bluegenes.test-utils :as utils]
+            [re-frame.core :as rf]
+            [day8.re-frame.test :refer-macros [run-test-sync run-test-async wait-for]]
+            [bluegenes.effects]))
+
+(use-fixtures :each utils/fixtures)
+
+(deftest retry
+  (run-test-async
+   (rf/reg-event-fx :test-retry (fn [_ _] {:retry {:event [:test-retry-success "melon"]}}))
+   (rf/reg-event-fx :test-retry-success (fn [_ [_ secret]]
+                                          {:db {:done secret}
+                                           :retry {:event [:test-retry-success]
+                                                   :success? true}}))
+   (rf/reg-sub :done (fn [db] (:done db)))
+   (rf/dispatch-sync [:test-retry])
+   (wait-for [:test-retry-success]
+     (let [code @(rf/subscribe [:done])]
+       (is (= code "melon") "Retry effect should dispatch event")))))

--- a/test/cljs/bluegenes/utils_test.cljs
+++ b/test/cljs/bluegenes/utils_test.cljs
@@ -1,6 +1,7 @@
 (ns bluegenes.utils-test
   (:require [cljs.test :refer-macros [deftest is are testing]]
-            [bluegenes.utils :as utils]))
+            [bluegenes.utils :as utils]
+            [bluegenes.version :as version]))
 
 (deftest read-xml-query
   (testing "Missing fields are correctly nulled"
@@ -133,75 +134,113 @@
 (deftest suitable-entities
   ;; Mock for model classes. We only check that the key is present.
   (let [model {:Gene {} :Protein {}}]
-    (is (= (utils/suitable-entities
-            model
-            {:Gene {:class "Gene" :format "id" :value 1}
-             :Protein {:class "Protein" :format "ids" :value [1 2 3]}}
-            {:accepts ["id"]
-             :classes ["Gene" "Protein"]})
-           {:Gene {:class "Gene" :format "id" :value 1}})
-        "Should remove invalid formats when accepts id")
-    (is (= (utils/suitable-entities
-            model
-            {:Gene {:class "Gene" :format "id" :value 1}
-             :Protein {:class "Protein" :format "ids" :value [1 2 3]}}
-            {:accepts ["ids"]
-             :classes ["Gene" "Protein"]})
-           {:Protein {:class "Protein" :format "ids" :value [1 2 3]}})
-        "Should remove invalid formats when accepts ids")
-    (is (= (utils/suitable-entities
-            model
-            {:Gene {:class "Gene" :format "id" :value 1}
-             :Protein {:class "Protein" :format "id" :value 2}}
-            {:accepts ["id"]
-             :classes ["Protein"]})
-           {:Protein {:class "Protein" :format "id" :value 2}})
-        "Should filter down to config's classes")
-    (is (= (utils/suitable-entities
-            model
-            {:Gene {:class "Gene" :format "id" :value 1}
-             :Protein {:class "Protein" :format "ids" :value [1 2 3]}}
-            {:accepts ["id" "ids"]
-             :classes ["*"]})
-           {:Gene {:class "Gene" :format "id" :value 1}
-            :Protein {:class "Protein" :format "ids" :value [1 2 3]}})
-        "Should handle wildcard in config's classes")
-    (is (= (utils/suitable-entities
-            model
-            {:Gene {:class "Gene" :format "id" :value 1}
-             :Protein {:class "Protein" :format "ids" :value [1 2 3]}}
-            {:accepts ["id" "ids"]
-             :classes ["Gene" "Protein"]
-             :depends ["Gene" "Protein"]})
-           {:Gene {:class "Gene" :format "id" :value 1}
-            :Protein {:class "Protein" :format "ids" :value [1 2 3]}})
-        "Should handle depends")
-    (testing "Should return nil when no entities are valid"
-      (are [entities config suitable]
-           (= (utils/suitable-entities model entities config) suitable)
+    (with-redefs [version/tool-api 1]
+      (is (= (utils/suitable-entities
+              model
+              {:Gene {:class "Gene" :format "id" :value 1}
+               :Protein {:class "Protein" :format "ids" :value [1 2 3]}}
+              {:accepts ["id"]
+               :classes ["Gene" "Protein"]})
+             {:Gene {:class "Gene" :format "id" :value 1}})
+          "Should remove invalid formats when accepts id")
+      (is (= (utils/suitable-entities
+              model
+              {:Gene {:class "Gene" :format "id" :value 1}
+               :Protein {:class "Protein" :format "ids" :value [1 2 3]}}
+              {:accepts ["ids"]
+               :classes ["Gene" "Protein"]})
+             {:Protein {:class "Protein" :format "ids" :value [1 2 3]}})
+          "Should remove invalid formats when accepts ids")
+      (is (= (utils/suitable-entities
+              model
+              {:Gene {:class "Gene" :format "id" :value 1}
+               :Protein {:class "Protein" :format "id" :value 2}}
+              {:accepts ["id"]
+               :classes ["Protein"]})
+             {:Protein {:class "Protein" :format "id" :value 2}})
+          "Should filter down to config's classes")
+      (is (= (utils/suitable-entities
+              model
+              {:Gene {:class "Gene" :format "id" :value 1}
+               :Protein {:class "Protein" :format "ids" :value [1 2 3]}}
+              {:accepts ["id" "ids"]
+               :classes ["*"]})
+             {:Gene {:class "Gene" :format "id" :value 1}
+              :Protein {:class "Protein" :format "ids" :value [1 2 3]}})
+          "Should handle wildcard in config's classes")
+      (is (= (utils/suitable-entities
+              model
+              {:Gene {:class "Gene" :format "id" :value 1}
+               :Protein {:class "Protein" :format "ids" :value [1 2 3]}}
+              {:accepts ["id" "ids"]
+               :classes ["Gene" "Protein"]
+               :depends ["Gene" "Protein"]})
+             {:Gene {:class "Gene" :format "id" :value 1}
+              :Protein {:class "Protein" :format "ids" :value [1 2 3]}})
+          "Should handle depends")
+      (testing "Should return nil when no entities are valid"
+        (are [entities config suitable]
+             (= (utils/suitable-entities model entities config) suitable)
 
-        {:Gene {:class "Gene" :format "id" :value 1}
-         :Protein {:class "Protein" :format "id" :value 2}}
-        {:accepts ["ids"]
-         :classes ["Gene" "Protein"]}
-        nil
+          {:Gene {:class "Gene" :format "id" :value 1}
+           :Protein {:class "Protein" :format "id" :value 2}}
+          {:accepts ["ids"]
+           :classes ["Gene" "Protein"]}
+          nil
 
-        {:Gene {:class "Gene" :format "id" :value 1}
-         :Protein {:class "Protein" :format "id" :value 2}}
-        {:accepts ["id"]
-         :classes ["OtherClass"]}
-        nil
+          {:Gene {:class "Gene" :format "id" :value 1}
+           :Protein {:class "Protein" :format "id" :value 2}}
+          {:accepts ["id"]
+           :classes ["OtherClass"]}
+          nil
 
-        {:Gene {:class "Gene" :format "id" :value 1}
-         :Protein {:class "Protein" :format "id" :value 2}}
-        {:accepts ["id"]
-         :classes ["Gene" "Protein"]
-         :depends ["NotInModel"]}
-        nil
+          {:Gene {:class "Gene" :format "id" :value 1}
+           :Protein {:class "Protein" :format "id" :value 2}}
+          {:accepts ["id"]
+           :classes ["Gene" "Protein"]
+           :depends ["NotInModel"]}
+          nil
 
-        {:Gene {:class "Gene" :format "id" :value 1}
-         :Protein {:class "Protein" :format "id" :value 2}}
-        {:accepts ["id"]
-         :classes ["*"]
-         :depends ["NotInModel"]}
-        nil))))
+          {:Gene {:class "Gene" :format "id" :value 1}
+           :Protein {:class "Protein" :format "id" :value 2}}
+          {:accepts ["id"]
+           :classes ["*"]
+           :depends ["NotInModel"]}
+          nil))
+      (is (= (utils/suitable-entities
+              model
+              {:Gene {:class "Gene" :format "id" :value 1}
+               :Protein {:class "Protein" :format "id" :value 2}}
+              {:accepts ["id"]
+               :classes ["Gene" "Protein"]
+               :version 2})
+             nil)
+          "Should return nil when tool version is above bluegenes"))
+    (with-redefs [version/tool-api 2]
+      (is (= (utils/suitable-entities
+              model
+              {:Gene {:class "Gene" :format "id" :value 1}
+               :Protein {:class "Protein" :format "id" :value 2}}
+              {:accepts ["id"]
+               :classes ["Gene" "Protein"]
+               :version 1})
+             nil)
+          "Should return nil when tool version is below bluegenes")
+      (is (= (utils/suitable-entities
+              model
+              {:Gene {:class "Gene" :format "id" :value 1}
+               :Protein {:class "Protein" :format "id" :value 2}}
+              {:accepts ["id"]
+               :classes ["Gene" "Protein"]})
+             nil)
+          "Should return nil when inferred tool version is below bluegenes")
+      (is (= (utils/suitable-entities
+              model
+              {:Gene {:class "Gene" :format "id" :value 1}
+               :Protein {:class "Protein" :format "id" :value 2}}
+              {:accepts ["id"]
+               :classes ["Gene" "Protein"]
+               :version 2})
+             {:Gene {:class "Gene" :format "id" :value 1}
+              :Protein {:class "Protein" :format "id" :value 2}})
+          "Should return entities when tool version is equal to bluegenes"))))


### PR DESCRIPTION
- Native viz support (see below for details)
  - **Cases** native viz for CovidMine
- Finalise tool support on list/query result page
  - Entity implemented for all classes (it used to be hardcoded to only work for genes)
  - Support for multiple entities to handle multiple query parts
  - Tools and native viz update when editing im-table
- Improvements to tool initialisation
  - Use a re-frame effect instead of side-effects inside `map` in view (which can run multiple times)
  - Remove reliance on subscribe (possible memory leak?)
  - Fix script/link elements being added every time, even when they already exist
  - Avoid Bluegenes halting when a tool throws an error by catching and logging them instead
- Tool API changes
  - Change imEntity to support multiple classes
  - Version key in *config.json*
  - Update documentation and add changelog to Tool API
- Collate version numbers used in Bluegenes into one namespace
  - Better documented and easier to reference

## Rationale for native viz

When creating the CovidMine visualization, it bothered me to no end that if I were to publish it as a Tool, it would probably amount to a 2MB bundle, as well as requiring a lot of boilerplate in a new repo. Since we will include vega-lite in BlueGenes to use in other visualizations, (specifically im-table multi-column summary automated plots) being able to re-use the library for this visualization meant big savings. Therefore I found the need for a *Tool Lite*, which in its simplest form consists of a vega-lite JSON spec along with a pathquery JSON. Since each native viz is just a namespace, code and component re-use is straightforward (something else I found difficult when each tool needed to be its own repository and npm package). It's also possible to re-use the query results across multiple native viz should they happen to use the same query; this will require some small modifications to the event handler running the native viz queries.

Native viz still have a config object similar to *config.json* and they follow the same rules on whether they should be displayed, as tools do. They also appear at the bottom of the tool store page. It is not currently possible to disable them like you can tools, but this can be added later. They follow the same `accepts`, `classes` and `depends` rules so they shouldn't appear when unwanted.

While this is ultimately a product of my laziness, I hope native viz will prove suitable as a lightweight alternative to tools, which just need to run a query and plot the results with vega-lite (which is very feature rich and flexible). If this turns out to be true, modularity and documentation can be added in the future to accomodate outside contributions. Nevertheless, tools are still the *de-facto* way of creating visualizations.