### PR TITLE
Blog posts preview on home page

### DIFF
--- a/less/components/home.less
+++ b/less/components/home.less
@@ -61,6 +61,30 @@
         }
     }
 
+    ul.latest-news {
+        list-style: none;
+        padding: 0;
+
+        li {
+            span {
+                display: block;
+                font-size: 0.9em;
+            }
+
+            a {
+                display: block;
+                font-weight: 400;
+                text-decoration: underline;
+            }
+
+            p {
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+            }
+        }
+    }
+
     .mine-intro {
         .mine-name {
             margin-bottom: @spacer;

--- a/src/clj/bluegenes/routes.clj
+++ b/src/clj/bluegenes/routes.clj
@@ -4,6 +4,7 @@
             [ring.util.response :refer [response]]
             [bluegenes.ws.auth :as auth]
             [bluegenes.ws.ids :as ids]
+            [bluegenes.ws.rss :as rss]
             [bluegenes.index :as index]))
 
 ; Define the top level URL routes for the server
@@ -16,6 +17,7 @@
   ; Anything within this route is the API web service:
   (context "/api" []
     (context "/auth" [] auth/routes)
-    (context "/ids" [] ids/routes))
+    (context "/ids" [] ids/routes)
+    (context "/rss" [] rss/routes))
 
   (GET "*" [] (index/index)))

--- a/src/clj/bluegenes/ws/rss.clj
+++ b/src/clj/bluegenes/ws/rss.clj
@@ -1,0 +1,57 @@
+(ns bluegenes.ws.rss
+  "Our Wordpress blog doesn't allow CORS, so we need to use the backend as a
+  proxy to fetch the RSS feed. Since we're already doing this, we might as well
+  parse the RSS here to reduce the payload back to the frontend."
+  (:require [compojure.core :refer [defroutes GET]]
+            [ring.middleware.params :refer [wrap-params]]
+            [ring.middleware.keyword-params :refer [wrap-keyword-params]]
+            [ring.util.http-response :as response]
+            [ring.util.http-predicates :as predicates]
+            [clj-http.client :as client]
+            [clojure.data.xml :as xml]
+            [clojure.zip :as z]))
+
+(defn find-items
+  "Returns a seq of item nodes for a zipper location."
+  [loc]
+  (cond
+    (z/end? loc) nil
+    (= :item (:tag (z/node loc))) (cons (z/node loc)
+                                        (filter map? (z/rights loc)))
+    :else (recur (z/next loc))))
+
+(defn find-tags
+  "Returns a map from tags to values for a zipper location."
+  ([loc tags] (find-tags loc tags {}))
+  ([loc tags m]
+   (cond
+     (z/end? loc) m
+     (empty? tags) m
+     (contains? tags (:tag (z/node loc)))
+     (let [{:keys [tag content]} (z/node loc)]
+       (recur (z/right loc) (disj tags tag) (assoc m tag (first content))))
+     :else (recur (z/next loc) tags m))))
+
+(defn parse-rss [xml-feed]
+  (->> (-> xml-feed xml/parse-str z/xml-zip find-items)
+       (map z/xml-zip)
+       (map #(find-tags % #{:title :link :pubDate :description}))))
+
+(defn fetch-rss [req]
+  (if-let [url (get-in req [:params :url])]
+    (let [res (client/get url)]
+      (if (predicates/ok? res)
+        (try
+          (if-let [parsed-items (not-empty (parse-rss (:body res)))]
+            (response/ok parsed-items)
+            (response/bad-request "Failed to parse RSS feed."))
+          (catch Exception e
+            (response/bad-request
+              (str "Error occured when parsing RSS feed: " (.getMessage e)))))
+        res))
+    (response/bad-request "Please pass a `url` query parameter pointing to an RSS feed.")))
+
+(defroutes routes
+  (wrap-params
+   (wrap-keyword-params
+    (GET "/parse" req fetch-rss))))

--- a/src/clj/bluegenes/ws/rss.clj
+++ b/src/clj/bluegenes/ws/rss.clj
@@ -47,7 +47,7 @@
             (response/bad-request "Failed to parse RSS feed."))
           (catch Exception e
             (response/bad-request
-              (str "Error occured when parsing RSS feed: " (.getMessage e)))))
+             (str "Error occured when parsing RSS feed: " (.getMessage e)))))
         res))
     (response/bad-request "Please pass a `url` query parameter pointing to an RSS feed.")))
 

--- a/src/cljs/bluegenes/effects.cljs
+++ b/src/cljs/bluegenes/effects.cljs
@@ -142,6 +142,7 @@
            uri
            headers
            timeout
+           query-params
            json-params
            transit-params
            form-params
@@ -160,6 +161,7 @@
                   :put http/put
                   http/get)]
     (let [c (http-fn uri (cond-> {}
+                           query-params (assoc :query-params query-params)
                            json-params (assoc :json-params json-params)
                            transit-params (assoc :transit-params transit-params)
                            form-params (assoc :form-params form-params)
@@ -290,3 +292,12 @@
                                   (gdom/getDocumentScroll)))]
      (doto (gfx/Scroll. doc-elem current-scroll #js [0 0] 500 ease-in-out-cubic)
        (.play)))))
+
+;; Currently this only logs to console, but in the future we can decide to
+;; include more information and perhaps log to a reporting service.
+(reg-fx
+ :log-error
+ (fn [[error-string data-map]]
+   (.error js/console
+           (str "bluegenes: " error-string)
+           (clj->js data-map))))

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -4,6 +4,8 @@
             [im-tables.events]
             [bluegenes.events.boot]
             [bluegenes.events.auth]
+            [bluegenes.events.registry]
+            [bluegenes.events.blog]
             [bluegenes.components.idresolver.events]
             [bluegenes.pages.mymine.events]
             [day8.re-frame.http-fx]
@@ -27,7 +29,6 @@
             [clojure.string :refer [join split]]
             [cljs.core.async :refer [put! chan <! >! timeout close!]]
             [imcljs.fetch :as fetch]
-            [bluegenes.events.registry :as registry]
             [cljs-bean.core :refer [->clj]]
             [bluegenes.utils :refer [read-registry-mine]]))
 

--- a/src/cljs/bluegenes/events/blog.cljs
+++ b/src/cljs/bluegenes/events/blog.cljs
@@ -4,10 +4,13 @@
 
 (def default-rss "https://intermineorg.wordpress.com/?feed=rss")
 
+(defn get-rss-from-db [db]
+  (get-in db [:mines (:current-mine db) :rss] default-rss))
+
 (reg-event-fx
  ::fetch-rss
  (fn [{db :db} [_]]
-   (let [rss (get-in db [:mines (:current-mine db) :rss] default-rss)]
+   (let [rss (get-rss-from-db db)]
      ;; Only fetch RSS if we haven't done it previously.
      (if (nil? (get-in db [:cache :rss rss]))
        {::fx/http {:uri "/api/rss/parse"

--- a/src/cljs/bluegenes/events/blog.cljs
+++ b/src/cljs/bluegenes/events/blog.cljs
@@ -1,0 +1,30 @@
+(ns bluegenes.events.blog
+  (:require [re-frame.core :refer [reg-event-db reg-event-fx]]
+            [bluegenes.effects :as fx]))
+
+(def default-rss "https://intermineorg.wordpress.com/?feed=rss")
+
+(reg-event-fx
+ ::fetch-rss
+ (fn [{db :db} [_]]
+   (let [rss (get-in db [:mines (:current-mine db) :rss] default-rss)]
+     ;; Only fetch RSS if we haven't done it previously.
+     (if (nil? (get-in db [:cache :rss rss]))
+       {::fx/http {:uri "/api/rss/parse"
+                   :method :get
+                   :on-success [::fetch-rss-success rss]
+                   :on-failure [::fetch-rss-failure rss]
+                   :on-unauthorised [::fetch-rss-failure rss]
+                   :query-params {:url rss}}}
+       {}))))
+
+(reg-event-db
+ ::fetch-rss-success
+ (fn [db [_ rss res]]
+   (assoc-in db [:cache :rss rss] res)))
+
+(reg-event-fx
+ ::fetch-rss-failure
+ (fn [{db :db} [_ rss res]]
+   {:db (assoc-in db [:cache :rss rss] false)
+    :log-error ["Fetch RSS failure" res]}))

--- a/src/cljs/bluegenes/events/blog.cljs
+++ b/src/cljs/bluegenes/events/blog.cljs
@@ -2,10 +2,12 @@
   (:require [re-frame.core :refer [reg-event-db reg-event-fx]]
             [bluegenes.effects :as fx]))
 
-(def default-rss "https://intermineorg.wordpress.com/?feed=rss")
+(def default-rss "https://intermineorg.wordpress.com/feed/")
 
 (defn get-rss-from-db [db]
-  (get-in db [:mines (:current-mine db) :rss] default-rss))
+  (if-let [rss (not-empty (get-in db [:mines (:current-mine db) :rss]))]
+    rss
+    default-rss))
 
 (reg-event-fx
  ::fetch-rss

--- a/src/cljs/bluegenes/events/webproperties.cljs
+++ b/src/cljs/bluegenes/events/webproperties.cljs
@@ -19,6 +19,7 @@
    ;;todo - set sane default programmatically or default to first.
    :default-selected-object-type (first (get-in web-properties [:genomicRegionSearch :defaultOrganisms]))
    :regionsearch-example         (get-in web-properties [:genomicRegionSearch :defaultSpans])
+   :rss                          (get-in web-properties [:project :rss])
    ;;this needs to be passed in as an arg or pulled from the branding endpoint.
    :icon                         "icon-intermine"
    :idresolver-example           (let [ids (get-in web-properties [:bag :example :identifiers])]

--- a/src/cljs/bluegenes/pages/home/subs.cljs
+++ b/src/cljs/bluegenes/pages/home/subs.cljs
@@ -1,6 +1,7 @@
 (ns bluegenes.pages.home.subs
   (:require [re-frame.core :refer [reg-sub]]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [bluegenes.events.blog :refer [get-rss-from-db]]))
 
 (reg-sub
  :home/root
@@ -56,3 +57,9 @@
  :<- [:home/mines-by-neighbourhood]
  (fn [[active-preview-mine registry sorted-mines]]
    (get registry active-preview-mine (-> sorted-mines rand-nth val))))
+
+(reg-sub
+ :home/latest-posts
+ (fn [db]
+   (let [rss (get-rss-from-db db)]
+     (get-in db [:cache :rss rss]))))

--- a/src/cljs/bluegenes/pages/home/subs.cljs
+++ b/src/cljs/bluegenes/pages/home/subs.cljs
@@ -58,6 +58,7 @@
  (fn [[active-preview-mine registry sorted-mines]]
    (get registry active-preview-mine (-> sorted-mines rand-nth val))))
 
+;; Be wary that this can return `false`, which many seq functions throw on.
 (reg-sub
  :home/latest-posts
  (fn [db]

--- a/src/cljs/bluegenes/pages/home/views.cljs
+++ b/src/cljs/bluegenes/pages/home/views.cljs
@@ -5,7 +5,10 @@
             [bluegenes.components.navbar.nav :refer [mine-icon]]
             [bluegenes.components.search.typeahead :as search]
             [clojure.string :as str]
-            [bluegenes.utils :refer [ascii-arrows ascii->svg-arrows md-paragraph]]))
+            [bluegenes.utils :refer [ascii-arrows ascii->svg-arrows md-paragraph]]
+            [goog.string :as gstring]
+            [cljs-time.format :as time-format]
+            [cljs-time.coerce :as time-coerce]))
 
 (defn mine-intro []
   (let [mine-name @(subscribe [:current-mine-human-name])
@@ -49,6 +52,20 @@
        "More queries here"]
       [:hr]]]))
 
+(def post-time-formatter (time-format/formatter "MMMM d, Y"))
+
+(defn latest-news []
+  (let [posts (take 3 @(subscribe [:home/latest-posts]))]
+    (if (empty? posts)
+      [:p "Latest news from the InterMine community."]
+      (into [:ul.latest-news]
+            (for [{:keys [title link pubDate description]} posts]
+              [:li
+               [:span (time-format/unparse post-time-formatter
+                                           (time-coerce/from-string pubDate))]
+               [:a {:href link :target "_blank"} title]
+               [:p (-> description gstring/unescapeEntities str/trim (subs 0 100))]])))))
+
 (defn call-to-action []
   [:div.row.section.grid ;; Without grid class the 3rd row won't be on the same row.
    ;; This isn't official bootstrap, so I can only imagine Gridlex is messing with things.
@@ -79,7 +96,7 @@
      "View documentation"]]
    [:div.col-xs-12.col-sm-5.cta-block
     [:h3.text-uppercase "What's new?"]
-    [:p "Latest news from the InterMine community."]
+    [latest-news]
     [:a.btn.btn-home
      {:href "https://intermineorg.wordpress.com/"
       :target "_blank"}

--- a/src/cljs/bluegenes/pages/home/views.cljs
+++ b/src/cljs/bluegenes/pages/home/views.cljs
@@ -55,7 +55,7 @@
 (def post-time-formatter (time-format/formatter "MMMM d, Y"))
 
 (defn latest-news []
-  (let [posts (take 3 @(subscribe [:home/latest-posts]))]
+  (let [posts (take 3 (or @(subscribe [:home/latest-posts]) nil))]
     (if (empty? posts)
       [:p "Latest news from the InterMine community."]
       (into [:ul.latest-news]

--- a/src/cljs/bluegenes/route.cljs
+++ b/src/cljs/bluegenes/route.cljs
@@ -80,6 +80,15 @@
                        ;; Hence, we need to dispatch `:results/load-history` manually.
                        [:results/load-history list-name]]})))))
 
+(defn dispatch-for-home
+  "Called when opening the home page.
+  This function is defined by itself as it needs to be referenced both in the
+  routes and when booting with no route match (i.e. empty URL path)."
+  []
+  (dispatch [:set-active-panel :home-panel
+             nil
+             [:bluegenes.events.blog/fetch-rss]]))
+
 ;;; Subscriptions ;;;
 
 (reg-sub
@@ -132,9 +141,7 @@
     [""
      {:name ::home
       :controllers
-      [{:start (fn []
-                 (dispatch [:bluegenes.events.blog/fetch-rss])
-                 (dispatch [:set-active-panel :home-panel]))}]}]
+      [{:start dispatch-for-home}]}]
     ["/profile"
      {:name ::profile
       :controllers
@@ -251,7 +258,8 @@
     (dispatch [::navigated new-match])
     ;; We end up here when the URL path is empty, so we'll set default mine.
     ;; (Usually this would be dispatched by the `/:mine` controller.)
-    (dispatch [:set-current-mine :default])))
+    (do (dispatch [:set-current-mine :default])
+        (dispatch-for-home))))
 
 (def router
   (rf/router

--- a/src/cljs/bluegenes/route.cljs
+++ b/src/cljs/bluegenes/route.cljs
@@ -132,7 +132,9 @@
     [""
      {:name ::home
       :controllers
-      [{:start #(dispatch [:set-active-panel :home-panel])}]}]
+      [{:start (fn []
+                 (dispatch [:bluegenes.events.blog/fetch-rss])
+                 (dispatch [:set-active-panel :home-panel]))}]}]
     ["/profile"
      {:name ::profile
       :controllers

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -182,6 +182,11 @@
    (get-in db [:cache :organisms])))
 
 (reg-sub
+ :cache/rss
+ (fn [db [_ rss]]
+   (get-in db [:cache :rss rss])))
+
+(reg-sub
  :current-mine
  (fn [db]
    (get-in db [:mines (get db :current-mine)])))


### PR DESCRIPTION
Shows previews of the three latest blog posts from the RSS feed registered for a mine, defaulting to the intermine wordpress blog.

The RSS feed is fetched and parsed on the backend, as our wordpress blog doesn't allow CORS (I guess this could be true for other organization's blogs as well).