### PR TITLE
Footer content and credits based on web-properties

### DIFF
--- a/src/cljs/bluegenes/components/footer/views.cljs
+++ b/src/cljs/bluegenes/components/footer/views.cljs
@@ -6,6 +6,11 @@
             [bluegenes.utils :refer [version-string->vec]]
             [bluegenes.components.icons :refer [icon]]))
 
+(def defaults
+  {:email "info@intermine.org"
+   :twitter "intermineorg"
+   :citation "https://intermineorg.wordpress.com/cite/"})
+
 (defn link [href label]
   [:a {:href href :target "_blank"} label])
 
@@ -13,7 +18,11 @@
   (->> vstring version-string->vec (str/join ".")))
 
 (defn main []
-  (let [short-version     (nth (re-matches #"v?([0-9\.]+)-.*" version/release) 1 "dev")
+  (let [mine-name         @(subscribe [:current-mine-human-name])
+        mine-twitter      @(subscribe [:registry/twitter])
+        mine-email        @(subscribe [:registry/email])
+        mine-citation     @(subscribe [:current-mine/citation])
+        short-version     (nth (re-matches #"v?([0-9\.]+)-.*" version/release) 1 "dev")
         ;; Note that the following versions can be nil when switching mines.
         intermine-version (some-> @(subscribe [:version]) pretty-version)
         api-version       (some-> @(subscribe [:api-version]) pretty-version)
@@ -36,19 +45,24 @@
       [link "https://github.com/intermine/"
        [poppable {:data [:span "Check out our open-source software"]
                   :children [icon "github" 2]}]]
-      [link "mailto:info@intermine.org"
-       [poppable {:data [:span "Send us an email"]
+      [link (str "mailto:" (or mine-email (:email defaults)))
+       [poppable {:data [:span (if (and mine-email (not= mine-email (:email defaults)))
+                                 (str "Send " mine-name " an email")
+                                 "Send us an email")]
                   :children [icon "mail" 2]}]]
       [link "https://intermineorg.wordpress.com/"
        [poppable {:data [:span "Read our blog"]
                   :children [icon "blog" 2]}]]
-      [link "https://twitter.com/intermineorg/"
-       [poppable {:data [:span "Follow us on Twitter"]
+      [link (str "https://twitter.com/" (or mine-twitter (:twitter defaults)))
+       [poppable {:data [:span (if (and mine-twitter (not= mine-twitter (:twitter defaults)))
+                                 (str "Follow " mine-name " on Twitter")
+                                 "Follow us on Twitter")]
                   :children [icon "twitter" 2]}]]
       [link "http://chat.intermine.org/"
        [poppable {:data [:span "Chat with us on Discord"]
                   :children [icon "discord" 2]}]]]
      [:div.section.column
-      [link "https://intermineorg.wordpress.com/cite/" "CITE US!"]
+      [link (or mine-citation (:citation defaults))
+       (str "CITE " (some-> mine-name str/upper-case))]
       [link "https://intermine.readthedocs.io/en/latest/about/" "ABOUT US"]
       [link "https://intermine.readthedocs.io/en/latest/about/privacy-policy/" "PRIVACY POLICY"]]]))

--- a/src/cljs/bluegenes/events/webproperties.cljs
+++ b/src/cljs/bluegenes/events/webproperties.cljs
@@ -29,13 +29,14 @@
    :regionsearch-example         (get-in web-properties [:genomicRegionSearch :defaultSpans])
    :rss                          (get-in web-properties [:project :rss])
    :citation                     (parse-citation (get-in web-properties [:project :citation]))
+   :credits                      (get-in web-properties [:project :credits])
    ;;this needs to be passed in as an arg or pulled from the branding endpoint.
    :icon                         "icon-intermine"
    :idresolver-example           (let [ids (get-in web-properties [:bag :example :identifiers])]
                                    ;; ids can be one of the following:
                                    ;;     {:default "foo bar"
-                                   ;;      :protein "baz "boz"} ; post im 4.1.0?
-                                   ;;     "foo bar"             ; pre  im 4.1.0?
+                                   ;;      :protein "baz boz"} ; post im 4.1.0?
+                                   ;;     "foo bar"            ; pre  im 4.1.0?
                                    ;; When it's a map, we capitalize the keys
                                    ;; and rename :Default to :Gene; otherwise
                                    ;; we make a map with ids assigned to :Gene.

--- a/src/cljs/bluegenes/events/webproperties.cljs
+++ b/src/cljs/bluegenes/events/webproperties.cljs
@@ -11,6 +11,14 @@
        string/capitalize
        keyword))
 
+(defn parse-citation
+  "Returns a URL citation or the URL of the first anchor element if it's HTML."
+  [citation]
+  (when-let [cit (not-empty citation)]
+    (or (re-matches #"\S+" cit) ;; If there are no spaces, it's probably a URL.
+        ;; Otherwise, extract it from the href attribute.
+        (second (re-find #"href=[\"']([^\"']+)" cit)))))
+
 (defn web-properties-to-bluegenes
   "Map intermine web properties to bluegenes properties"
   [web-properties previous-properties]
@@ -20,6 +28,7 @@
    :default-selected-object-type (first (get-in web-properties [:genomicRegionSearch :defaultOrganisms]))
    :regionsearch-example         (get-in web-properties [:genomicRegionSearch :defaultSpans])
    :rss                          (get-in web-properties [:project :rss])
+   :citation                     (parse-citation (get-in web-properties [:project :citation]))
    ;;this needs to be passed in as an arg or pulled from the branding endpoint.
    :icon                         "icon-intermine"
    :idresolver-example           (let [ids (get-in web-properties [:bag :example :identifiers])]

--- a/src/cljs/bluegenes/pages/home/views.cljs
+++ b/src/cljs/bluegenes/pages/home/views.cljs
@@ -225,8 +225,6 @@
       [:img.img-responsive
        {:src image}]]]))
 
-;; TODO maybe this should be in the properties file by default?
-;; - so the images will get hosted on the InterMine backend of the mine
 (def credits-intermine
   [{:text "InterMine has been developed principally through support of the [Wellcome Trust](https://wellcome.ac.uk/). Complementary projects have been funded by the [NIH/NHGRI](https://www.nih.gov/) and the [BBSRC](https://bbsrc.ukri.org/)."
     :image "https://www.humanmine.org/humanmine/images/icons/intermine-footer-logo.png"
@@ -253,8 +251,7 @@
 
 (defn credits []
   (let [mine-name @(subscribe [:current-mine-human-name])
-        ;; TODO replace `entries` with web-properties
-        entries []
+        entries @(subscribe [:current-mine/credits])
         all-entries (concat entries credits-intermine)]
     [:div.row.section
      [:div.col-xs-12
@@ -263,10 +260,9 @@
        [:div.col-xs-12.text-center
         [credits-fallback]])
      [:div.col-xs-10.col-xs-offset-1
-      [:div.row.row-center-cols.row-space-cols
-       (for [[i entry] (map-indexed vector all-entries)]
-         ^{:key i}
-         [credits-entry entry])]]]))
+      (into [:div.row.row-center-cols.row-space-cols]
+            (for [entry all-entries]
+              [credits-entry entry]))]]))
 
 (defn main []
   [:div.container.home

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -192,6 +192,12 @@
    (get-in db [:mines (get db :current-mine)])))
 
 (reg-sub
+ :current-mine/citation
+ :<- [:current-mine]
+ (fn [current-mine]
+   (:citation current-mine)))
+
+(reg-sub
  :current-mine-human-name
  :<- [:current-mine]
  (fn [current-mine]
@@ -270,6 +276,20 @@
  :<- [:current-mine-name]
  (fn [[registry current-mine]]
    (get-in registry [current-mine :description])))
+
+(reg-sub
+ :registry/twitter
+ :<- [:registry]
+ :<- [:current-mine-name]
+ (fn [[registry current-mine]]
+   (not-empty (get-in registry [current-mine :twitter]))))
+
+(reg-sub
+ :registry/email
+ :<- [:registry]
+ :<- [:current-mine-name]
+ (fn [[registry current-mine]]
+   (not-empty (get-in registry [current-mine :maintainerEmail]))))
 
 ;;;; Styling
 

--- a/src/cljs/bluegenes/subs.cljs
+++ b/src/cljs/bluegenes/subs.cljs
@@ -198,6 +198,12 @@
    (:citation current-mine)))
 
 (reg-sub
+ :current-mine/credits
+ :<- [:current-mine]
+ (fn [current-mine]
+   (:credits current-mine)))
+
+(reg-sub
  :current-mine-human-name
  :<- [:current-mine]
  (fn [current-mine]


### PR DESCRIPTION
The footer content and home page credits now change based on the response from the web-properties webservice.

Fixes #532
Fixes #531

Before merging, this should be tested against a deployed Intermine with the web-properties `project.credits` key populated with the following (or whatever it is in XML) which should show up in the Bluegenes credits section.

```
{
  "credits": [
    {
      "image": "https://bar.utoronto.ca/thalemine/images/CAGEF.png",
      "url": "http://www.cagef.utoronto.ca/"
    },
    {
      "text": "The [Legume Information System (LIS)](https://legumeinfo.org/) is a research project of the [USDA-ARS:Corn Insects and Crop Genetics Research](https://www.ars.usda.gov/midwest-area/ames/cicgru/) in Ames, IA.",
      "image": "https://mines.legumeinfo.org/beanmine/model/images/USDA-92x67.png",
      "url": "https://usda.gov/"
    }
  ]
}
```