### PR TITLE
Button to generate permanent URL for report page

### DIFF
--- a/less/components/report.less
+++ b/less/components/report.less
@@ -261,6 +261,16 @@
             list-style-type: none;
             padding-left: @spacer;
             overflow: hidden;
+
+            &.sidebar-actions {
+                overflow: visible;
+
+                .permanent-url-container {
+                    padding: @spacer/4 @spacer/2;
+
+                    p { padding: 0; }
+                }
+            }
         }
 
         li {
@@ -285,8 +295,15 @@
                     align-items: center;
                 }
 
-                .icon {
+                .icon-external {
                     margin: 0;
+                }
+
+                &.sidebar-action {
+                    display: flex;
+                    align-items: center;
+                    color: @highlight-color;
+                    fill: @highlight-color;
                 }
             }
         }

--- a/project.clj
+++ b/project.clj
@@ -79,7 +79,7 @@
 
                  ; Intermine Assets
                  [org.intermine/im-tables "0.11.0"]
-                 [org.intermine/imcljs "1.3.0"]
+                 [org.intermine/imcljs "1.3.1"]
                  [org.intermine/bluegenes-tool-store "0.2.0"]]
 
   :deploy-repositories {"clojars" {:sign-releases false}}

--- a/src/cljs/bluegenes/interceptors.cljs
+++ b/src/cljs/bluegenes/interceptors.cljs
@@ -36,3 +36,17 @@
    :id :clear-tooltips
    :after (fn [context] (ocall (js/$ ".popover") "remove") context)))
 
+(defn- get-origin
+  "Returns a string representing the origin URL of the webapp."
+  []
+  (let [loc (.-location js/window)]
+    (str (.-protocol loc) "//" (.-host loc))))
+
+(defn origin
+  "Provides a re-frame interceptor that adds an :origin key to the context,
+  containing the origin URL of the webapp."
+  []
+  (re-frame.core/->interceptor
+   :id :origin
+   :before (fn [context]
+             (assoc-in context [:coeffects :origin] (get-origin)))))

--- a/src/cljs/bluegenes/pages/reportpage/subs.cljs
+++ b/src/cljs/bluegenes/pages/reportpage/subs.cljs
@@ -153,3 +153,9 @@
    (subscribe [:bluegenes.pages.admin.subs/available-class-names class]))
  (fn [refs+colls [_ _class]]
    (into #{} (map :value refs+colls))))
+
+(reg-sub
+ ::share
+ :<- [::report]
+ (fn [report]
+   (:share report)))

--- a/src/cljs/bluegenes/route.cljs
+++ b/src/cljs/bluegenes/route.cljs
@@ -267,7 +267,13 @@
                  (dispatch [:set-active-panel :reportpage-panel
                             {:type type, :id id, :format "id", :mine mine}
                             [:load-report mine type id]]))
-        :stop #(dispatch [:bluegenes.pages.reportpage.events/stop-scroll-handling])}]}]]])
+        :stop #(dispatch [:bluegenes.pages.reportpage.events/stop-scroll-handling])}]}]
+    ["/share/:lookup"
+     {:name ::share
+      :controllers
+      [{:parameters {:path [:mine :lookup]}
+        :start (fn [{{:keys [mine lookup]} :path}]
+                 (dispatch [:handle-permanent-url mine lookup]))}]}]]])
 ;; You can do initialisations by adding a :start function to :controllers.
 ;; :start (fn [& params] (js/console.log "Entering page"))
 ;; Teardowns can also be done by using the :stop key.


### PR DESCRIPTION
Add a button to the top of the report page sidebar which runs a request to generate a permanent URL for the displayed report page, and displays the URL in a dropdown (similarly to the *Share* button on the JSP webapp report page). The URL path looks like `/humanmine/share/gene:123` and Bluegenes will redirect to the respective report page from this URL.

Depends on imcljs 1.3.1 which I recently published.

Fixes #83, fixes #431