### PR TITLE
Generate API key in profile page

### DIFF
--- a/less/components/profile.less
+++ b/less/components/profile.less
@@ -59,4 +59,8 @@
         margin-top: @spacer;
         margin-bottom: @spacer;
     }
+
+    .token-box {
+        font-size: 1.4em;
+    }
 }

--- a/src/cljs/bluegenes/pages/profile/subs.cljs
+++ b/src/cljs/bluegenes/pages/profile/subs.cljs
@@ -20,3 +20,8 @@
  ::preferences
  (fn [db]
    (get-in db [:profile :preferences])))
+
+(reg-sub
+ ::api-key
+ (fn [db]
+   (get-in db [:profile :api-key])))

--- a/src/cljs/bluegenes/version.cljs
+++ b/src/cljs/bluegenes/version.cljs
@@ -6,6 +6,7 @@
 
 ;;;; Version numbers you *wouldn't* want to change (collected for reference).
 
+;; Minimum InterMine API version Bluegenes supports.
 ;; this is not crazy to hardcode. The consequences of a mine that is lower than
 ;; the minimum version using bluegenes could potentially result in corrupt lists
 ;; so it *should* be hard to change.
@@ -21,6 +22,13 @@
 ;; depend on this and will show a useful warning with fallback behaviour if not
 ;; available.
 (def bg-properties-support "5.0.0")
+
+;; Prior to this InterMine API version, BlueGenes "logins" to the mine by using
+;; basic-auth with username and password to the generate API access key
+;; webservice. This is problematic as only one API token can exist a time,
+;; meaning it will both invalidate any existing API key, and get invalidated
+;; when a new API key is generated.
+(def proper-login-support 31)
 
 ;;;; Version numbers you *might* want to change.
 


### PR DESCRIPTION
Adds a new *API access key* panel to the logged in user's profile page.

Due to how the web service works, there's some differences from the legacy webapp:
1. You won't be able to see the previously generated API key (ws doesn't allow you to see API key for security reasons; this means you'll only see a newly generated API key)
2. You can't delete an existing API key, but you can still generate a new one to invalidate it (ws doesn't allow you to delete an API key, and if it did, it would make less sense due to 1)

Closes #472.

Note that this depends on `imcljs.auth/create-token` which is yet to be released (but should be in a few days).