### PR TITLE
Show uncaught errors in a friendly error boundary page

### DIFF
--- a/less/components/error.less
+++ b/less/components/error.less
@@ -1,0 +1,34 @@
+@import "../variables";
+@import "icons";
+
+.error-page {
+    padding-top: @spacer*4;
+    padding-bottom: @spacer*4;
+
+    .heading {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin-top: @spacer;
+        margin-bottom: @spacer*2;
+
+        h1 {
+            margin-top: 0;
+        }
+
+        .icon {
+            margin-right: @spacer*2 !important;
+            fill: @notice-me;
+            .icon(5em)
+        }
+    }
+
+    p {
+        font-size: 1.1em;
+    }
+
+    .button-group {
+        display: flex;
+        justify-content: space-between;
+    }
+}

--- a/less/site.less
+++ b/less/site.less
@@ -25,6 +25,7 @@
 @import "components/constraints";
 @import "components/viz";
 @import "components/tools";
+@import "components/error";
 @import "layouts/input-group";
 @import "layouts/header";
 @import "developer";

--- a/src/cljs/bluegenes/error.cljs
+++ b/src/cljs/bluegenes/error.cljs
@@ -1,0 +1,97 @@
+(ns bluegenes.error
+  (:require [re-frame.core :refer [subscribe dispatch-sync]]
+            [reagent.core :as reagent]
+            [oops.core :refer [oget]]
+            [goog.json :as json]
+            [goog.string :as gstring]
+            [cljs-time.core :as time]
+            [cljs-time.format :refer [unparse formatters]]))
+
+;; This email is used if no maintainerEmail is available, or when we wish to
+;; CC support (ie. when the failure is caused by a software problem).
+(def support-email "info@intermine.org")
+
+(defn mailto-string [error]
+  (let [maintainer-email (or @(subscribe [:registry/email]) support-email)
+        current-url (oget js/window :location :href)
+        service-url (get-in @(subscribe [:current-mine]) [:service :root])
+        current-date (unparse (formatters :rfc822) (time/now))]
+    (str "mailto:" maintainer-email
+         "?subject=" (gstring/urlEncode "[BLUEGENES] - Uncaught error")
+         "&cc=" support-email
+         "&body=" (gstring/urlEncode
+                   (str "We encountered an error in BlueGenes.
+
+page: " current-url "
+service: " service-url "
+date: " current-date "
+-------------------------------
+ERROR: " error)))))
+
+(defn error-string [{:keys [error info]}]
+  (str error
+       \newline
+       (or (oget info :componentStack)
+           (json/serialize info))))
+
+(defn error-icons []
+  [:svg
+   {:version "1.1"
+    :height "0"
+    :width "0"
+    :style {:position "absolute" :width 0 :height 0}}
+   [:defs
+    [:symbol#icon-bug
+     {:viewBox "0 0 32 32"}
+     [:path
+      {:d
+       "M32 18v-2h-6.040c-0.183-2.271-0.993-4.345-2.24-6.008h5.061l2.189-8.758-1.94-0.485-1.811 7.242h-5.459c-0.028-0.022-0.056-0.043-0.084-0.064 0.21-0.609 0.324-1.263 0.324-1.944 0-3.305-2.686-5.984-6-5.984s-6 2.679-6 5.984c0 0.68 0.114 1.334 0.324 1.944-0.028 0.021-0.056 0.043-0.084 0.064h-5.459l-1.811-7.242-1.94 0.485 2.189 8.758h5.061c-1.246 1.663-2.056 3.736-2.24 6.008h-6.040v2h6.043c0.119 1.427 0.485 2.775 1.051 3.992h-3.875l-2.189 8.757 1.94 0.485 1.811-7.243h3.511c1.834 2.439 4.606 3.992 7.708 3.992s5.874-1.554 7.708-3.992h3.511l1.811 7.243 1.94-0.485-2.189-8.757h-3.875c0.567-1.217 0.932-2.565 1.051-3.992h6.043z"}]]]])
+
+(defn error-panel [{:keys [error on-reset]}]
+  (let [error-text (error-string error)]
+    [:div.well.well-lg.error-container
+     [:div.heading
+      [:svg.icon.icon-bug [:use {:xlinkHref "#icon-bug"}]]
+      [:div
+       [:h1 "Something went wrong!"]
+       [:h4 "BlueGenes experienced an uncaught error"]]]
+     [:p "This could indicate a bug in BlueGenes or the InterMine instance returning malformed data. If you think BlueGenes should be able to handle this error, please send a pre-filled bug report by clicking the button below. Any description of what you were doing before this happened would be very helpful."]
+     [:p "Use the " [:em "Reset"] " button below to start BlueGenes from a blank slate."]
+     [:pre.text-danger error-text]
+     [:div.button-group
+      [:button.btn.btn-raised.btn-primary
+       {:on-click on-reset}
+       "Reset"]
+      [:a.btn.btn-raised.btn-primary
+       {:href (mailto-string error-text)}
+       [:i.fa.fa-envelope] " Send a bug report"]]]))
+
+(defn error-boundary
+  [& children]
+  (let [caught? (reagent/atom false)
+        !error (reagent/atom nil)]
+    (reagent/create-class
+     {:display-name "BlueGenesRootErrorBoundary"
+      :get-derived-state-from-error (fn [_]
+                                      (reset! caught? true)
+                                      #js {})
+      :component-did-catch (fn [_ error info]
+                             (reset! !error {:error error :info info}))
+      :render (fn [this]
+                (let [clear-error! (fn []
+                                     ;; Change URL to root without triggering router.
+                                     (.pushState js/window.history nil "" "/")
+                                     ;; Boot and clear error.
+                                     (dispatch-sync [:boot])
+                                     (reset! !error nil)
+                                     (reset! caught? false))]
+                  (if @caught?
+                    (when-let [error @!error]
+                      [:div.approot
+                       [error-icons]
+                       [:main
+                        [:div.container.error-page
+                         [error-panel
+                          {:error error
+                           :on-reset clear-error!}]]]])
+                    (into [:<>] (reagent/children this)))))})))

--- a/src/cljs/bluegenes/views.cljs
+++ b/src/cljs/bluegenes/views.cljs
@@ -1,6 +1,5 @@
 (ns bluegenes.views
-  (:require [re-frame.core :as re-frame :refer [subscribe dispatch]]
-            [json-html.core :as json-html]
+  (:require [re-frame.core :as re-frame :refer [subscribe]]
             [bluegenes.pages.developer.devhome :as dev]
             [bluegenes.components.navbar.nav :as nav]
             [bluegenes.components.footer.views :as footer]
@@ -19,7 +18,8 @@
             [bluegenes.pages.profile.views :as profile]
             [bluegenes.pages.admin.views :as admin]
             [bluegenes.pages.tools.view :as tools]
-            [bluegenes.components.loader :as loader]))
+            [bluegenes.components.loader :as loader]
+            [bluegenes.error :refer [error-boundary]]))
 
 (enable-console-print!)
 
@@ -45,12 +45,13 @@
         main-color (subscribe [:branding/header-main])
         text-color (subscribe [:branding/header-text])]
     (fn []
-      [:div.approot
-       {:style {"--branding-header-main" @main-color
-                "--branding-header-text" @text-color}}
-       [loader/mine-loader]
-       [icons/icons]
-       [nav/main]
-       [:main [show-panel @active-panel]]
-       [footer/main]
-       [alerts/main]])))
+      [error-boundary
+       [:div.approot
+        {:style {"--branding-header-main" @main-color
+                 "--branding-header-text" @text-color}}
+        [loader/mine-loader]
+        [icons/icons]
+        [nav/main]
+        [:main [show-panel @active-panel]]
+        [footer/main]
+        [alerts/main]]])))


### PR DESCRIPTION
Uses React's [error boundaries](https://reactjs.org/docs/error-boundaries.html) feature to wrap the entire webapp in a "try-catch" component. If an uncaught error bubbles up to the root, instead of crashing and a blank page being shown, it will show an appropriate error page with options to send a bug report or reset Bluegenes (similar to the error state in an im-table).

Closes #486