### PR TITLE
Handle permanent URL without /share

### DIFF
--- a/config/defaults/config.edn
+++ b/config/defaults/config.edn
@@ -1,2 +1,5 @@
 {;; Where BlueGenes tools are installed.
- :bluegenes-tool-path "./tools"}
+ :bluegenes-tool-path "./tools"
+ :bluegenes-default-service-root "https://www.flymine.org/flymine"
+ :bluegenes-default-mine-name "FlyMine"
+ :bluegenes-default-namespace "flymine"}

--- a/src/clj/bluegenes/index.clj
+++ b/src/clj/bluegenes/index.clj
@@ -24,37 +24,45 @@
   [:style
    "#csscompiling{position:fixed;bottom:0;right:0;padding:20px;height:100px;width:400px;background-color:#FFA726;}"])
 
-(defn head []
-  [:head
-   loader-style
-   css-compiling-style
-   [:title "InterMine 2.0 BlueGenes"]
-   (include-css "https://cdnjs.cloudflare.com/ajax/libs/gridlex/2.2.0/gridlex.min.css")
-   (include-css "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css")
-   (include-css bluegenes-css)
-   (include-css im-tables-css)
-   (include-css "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css")
-   (include-css "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css")
-   ; Meta data:
-   [:meta {:charset "utf-8"}]
-   [:meta {:content "width=device-width, initial-scale=1", :name "viewport"}]
-   ;;outputting clj-based vars for use in the cljs:
-   [:script
-    (str "var serverVars="
-         (generate-string {:googleAnalytics (:google-analytics env)
-                           :serviceRoot     (:bluegenes-default-service-root env)
-                           :mineName        (:bluegenes-default-mine-name env)
-                           :version         bundle-hash})
-         ";")]
+(defn head
+  ([]
+   (head nil))
+  ([init-vars]
+   [:head
+    loader-style
+    css-compiling-style
+    [:title "InterMine 2.0 BlueGenes"]
+    (include-css "https://cdnjs.cloudflare.com/ajax/libs/gridlex/2.2.0/gridlex.min.css")
+    (include-css "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css")
+    (include-css bluegenes-css)
+    (include-css im-tables-css)
+    (include-css "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css")
+    (include-css "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/github.min.css")
+    ; Meta data:
+    [:meta {:charset "utf-8"}]
+    [:meta {:content "width=device-width, initial-scale=1", :name "viewport"}]
+    ;;outputting clj-based vars for use in the cljs:
+    [:script
+     (str "var serverVars="
+          (generate-string {:googleAnalytics (:google-analytics env)
+                            :serviceRoot     (:bluegenes-default-service-root env)
+                            :mineName        (:bluegenes-default-mine-name env)
+                            :version         bundle-hash})
+          ";")
+     (str "var initVars="
+          (if (map? init-vars)
+            (str \' (pr-str init-vars) \')
+            "null")
+          ";")]
   ; Javascript:
-   [:link {:rel "shortcut icon" :href "https://raw.githubusercontent.com/intermine/design-materials/f5f00be4/logos/intermine/fav32x32.png" :type "image/png"}]
-   [:script {:src "https://cdn.intermine.org/js/intermine/imjs/3.15.0/im.min.js"}]
-   [:script {:crossorigin "anonymous"
-             :integrity "sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="
-             :src "https://code.jquery.com/jquery-3.1.0.min.js"}]
-   [:script {:crossorigin "anonymous"
-             :src "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"}]
-   [:script {:src "https://apis.google.com/js/api.js"}]])
+    [:link {:rel "shortcut icon" :href "https://raw.githubusercontent.com/intermine/design-materials/f5f00be4/logos/intermine/fav32x32.png" :type "image/png"}]
+    [:script {:src "https://cdn.intermine.org/js/intermine/imjs/3.15.0/im.min.js"}]
+    [:script {:crossorigin "anonymous"
+              :integrity "sha256-cCueBR6CsyA4/9szpPfrX3s49M9vUU5BgtiJj06wt/s="
+              :src "https://code.jquery.com/jquery-3.1.0.min.js"}]
+    [:script {:crossorigin "anonymous"
+              :src "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"}]
+    [:script {:src "https://apis.google.com/js/api.js"}]]))
 
 (defn loader []
   [:div#wrappy
@@ -78,14 +86,16 @@
 
 (defn index
   "Hiccup markup that generates the landing page and loads the necessary assets."
-  []
-  (html5
-   (head)
-   [:body
-    (css-compiler)
-    (loader)
-    [:div#app]
-    [:script {:src bundle-path}]
-    ;; Call the constructor of the bluegenes client and pass in the user's
-    ;; optional identity as an object.
-    [:script "bluegenes.core.init();"]]))
+  ([]
+   (index nil))
+  ([init-vars]
+   (html5
+    (head init-vars)
+    [:body
+     (css-compiler)
+     (loader)
+     [:div#app]
+     [:script {:src bundle-path}]
+     ;; Call the constructor of the bluegenes client and pass in the user's
+     ;; optional identity as an object.
+     [:script "bluegenes.core.init();"]])))

--- a/src/clj/bluegenes/routes.clj
+++ b/src/clj/bluegenes/routes.clj
@@ -29,5 +29,5 @@
   ;; to the frontend to session.init, in which case we make sure to pass it on
   ;; and remove it (as it gets "consumed") from the session.
   (GET "*" {{:keys [init] :as session} :session}
-       (-> (response (index/index init))
-           (assoc :session (dissoc session :init)))))
+    (-> (response (index/index init))
+        (assoc :session (dissoc session :init)))))

--- a/src/clj/bluegenes/ws/lookup.clj
+++ b/src/clj/bluegenes/ws/lookup.clj
@@ -1,0 +1,39 @@
+(ns bluegenes.ws.lookup
+  (:require [imcljs.fetch :as im-fetch]
+            [ring.util.http-response :as response]
+            [config.core :refer [env]]
+            [clojure.string :as str]
+            [cheshire.core :as cheshire]))
+
+(defn handle-failed-lookup [lookup-string error-string]
+  (let [msg [:span "Failed to parse permanent URL for " [:em lookup-string] " "
+             [:code error-string]]]
+    (-> (response/found "/")
+        (assoc :session {:init {:events [[:messages/add
+                                          {:style "warning"
+                                           :timeout 0
+                                           :markup msg}]]}}))))
+
+(defn ws [lookup-string]
+  (try
+    (let [[object-type identifier] (str/split lookup-string #":")
+          object-type (str/capitalize object-type)
+          service {:root (:bluegenes-default-service-root env)
+                   :model {:name "genomic"}}
+          q {:from object-type
+             :select [(str object-type ".id")]
+             :where [{:path object-type
+                      :op "LOOKUP"
+                      :value identifier}]}
+          res (im-fetch/rows service q)]
+      (if-let [object-id (get-in res [:results 0 0])]
+        (response/found (str "/" (:bluegenes-default-namespace env)
+                             "/" "report"
+                             "/" object-type
+                             "/" object-id))
+        (handle-failed-lookup lookup-string "The identifier does not seem to be in the database anymore.")))
+    (catch Exception e
+      (let [{:keys [body]} (ex-data e)
+            {:keys [error]} (cheshire/parse-string body true)]
+        (handle-failed-lookup lookup-string (or (not-empty error)
+                                                "Error occurred when querying identifier"))))))

--- a/src/cljs/bluegenes/pages/reportpage/events.cljs
+++ b/src/cljs/bluegenes/pages/reportpage/events.cljs
@@ -8,8 +8,7 @@
             [bluegenes.route :as route]
             [goog.dom :as gdom]
             [oops.core :refer [oget ocall]]
-            [bluegenes.utils :refer [rows->maps]]
-            [bluegenes.interceptors :refer [origin]]))
+            [bluegenes.utils :refer [rows->maps]]))
 
 (reg-event-fx
  :fetch-fasta
@@ -226,19 +225,11 @@
                 :on-success [::show-permanent-url]
                 :on-failure [::show-permanent-url-error]}})))
 
-(reg-event-fx
+(reg-event-db
  ::show-permanent-url
- [(origin)]
- (fn [{db :db origin :origin} [_ url]]
-   ;; url can't be an empty string; on-failure would be called instead.
-   (let [lookup-string (re-find #"[^/]+$" url)
-         ;; The webservice returns the JSP webapp URL. We only grab the last
-         ;; part of the URL and use that to build a BlueGenes permanent URL.
-         bluegenes-url
-         (str origin (js/decodeURIComponent ; href automatically URI encodes the ':' character.
-                      (route/href ::route/share {:lookup lookup-string})))]
-     {:db (assoc-in db [:report :share] {:status :success
-                                         :url bluegenes-url})})))
+ (fn [db [_ url]]
+   (assoc-in db [:report :share] {:status :success
+                                  :url url})))
 
 (reg-event-db
  ::show-permanent-url-error


### PR DESCRIPTION
This PR adds support for permanent URL paths of the form `/humanmine/gene:5468`. These are detected using routing regex and handled on the Bluegenes backend, which makes it much faster. The downside is that unlike the `/humanmine/share/gene:5468` URLs, they cannot handle any mines other than the configured one. This shouldn't be a problem once Bluegenes gets deployed for the respective mines; until then the permanent URLs will point to the legacy webapp.

I will underline that this also changes the generated permanent URL, so that Bluegenes no longer replaces the mine's service URL with Bluegenes' origin. While it's not optimal UX to begin with, I think it's the better solution in the long run.

Resolves #590.