### PR TITLE
Handle invalid routes

### DIFF
--- a/src/clj/bluegenes/handler.clj
+++ b/src/clj/bluegenes/handler.clj
@@ -9,7 +9,20 @@
             [ring.middleware.reload :refer [wrap-reload]]
             [ring.middleware.format :refer [wrap-restful-format]]
             [compojure.core :refer [routes]]
+            [compojure.middleware :refer [wrap-canonical-redirect]]
             [bluegenes-tool-store.core :as tool]))
+
+(defn remove-trailing-slash
+  "Remove the trailing '/' from a URI string, if it exists and isn't the only character."
+  [^String uri]
+  (if (.endsWith uri "/")
+    (let [len (.length uri)]
+      ;; Without this check, the response becomes 301 with a blank Location
+      ;; header for request uri path "/", causing nothing to be loaded.
+      (if (> len 1)
+        (.substring uri 0 (dec len))
+        uri))
+    uri))
 
 (def combined-routes
   (routes tool/routes routes/routes))
@@ -20,4 +33,7 @@
                  ; Add session functionality to the Ring requests
                  wrap-session
                  ; Accept and parse request parameters in various formats
-                 (wrap-restful-format :formats [:json :json-kw :transit-msgpack :transit-json])))
+                 (wrap-restful-format :formats [:json :json-kw :transit-msgpack :transit-json])
+                 ; Redirect to the correct route when trailing slash is present in path.
+                 ; This is for the frontend router, which doesn't handle trailing slashes.
+                 (wrap-canonical-redirect remove-trailing-slash)))


### PR DESCRIPTION
Routes that contain a trailing slash now redirect to the path without a trailing slash on Bluegenes backend.

Malformed routes have their mine salvaged (or load the default mine if referenced mine is nonexistent) and the home page shown with error messages explaining the invalid mine name or path.

Resolves  #516
Resolves #517