### PR TITLE
Various fixes for querybuilder constraints and template running

### DIFF
--- a/cypress/integration/login_spec.js
+++ b/cypress/integration/login_spec.js
@@ -19,6 +19,8 @@ describe("Authentication Tests", function() {
 		});
 
     cy.getCookie("ring-session").should('exist');
+
+    cy.wait(500);
     cy.get(".logon.dropdown").click();
     cy.get(".logon.dropdown").contains("test_user@mail_account").should('be.visible');
     cy.get(".logon.dropdown").contains('Logout').click();

--- a/less/components/constraints.less
+++ b/less/components/constraints.less
@@ -1,6 +1,8 @@
 @import "../variables";
 
 .list-dropdown {
+    max-width: 100%;
+
     .dropdown-toggle {
         text-transform: none;
         white-space: normal;

--- a/src/cljs/bluegenes/components/ui/constraint.cljs
+++ b/src/cljs/bluegenes/components/ui/constraint.cljs
@@ -73,12 +73,14 @@
   "Set of operators that don't require a value."
   (set (map :op (filter :no-value? operators))))
 
+(def not-blank? (complement blank?))
+
 (defn satisfied-constraint?
   "Returns true if the passed constraint has the argument required by the operator, else false."
   [{:keys [value values type op] :as _constraint}]
   (or (contains? operators-no-value op)
-      (and (some? op) (or (some? value) (some? values)))
-      (and (nil? op) (some? type))))
+      (and (not-blank? op) (or (not-blank? value) (not-blank? values)))
+      (and (nil? op) (not-blank? type))))
 
 (defn list-op? [op]
   (contains? #{"IN" "NOT IN"} op))

--- a/src/cljs/bluegenes/pages/querybuilder/events.cljs
+++ b/src/cljs/bluegenes/pages/querybuilder/events.cljs
@@ -470,10 +470,10 @@
          updated-constraint (cond-> (constraint/clear-constraint-value old-constraint constraint)
                               add-code? (assoc :code (next-available-const-code (get-in db [:qb :enhance-query])))
                               remove-code? (dissoc :code))]
-       (cond-> db
-         updated-constraint (assoc-in constraint-path updated-constraint)
-         add-code? (update-in [:qb :constraint-logic] append-code (symbol (:code updated-constraint)))
-         remove-code? (update-in [:qb :constraint-logic] remove-code (symbol (:code constraint)))))))
+     (cond-> db
+       updated-constraint (assoc-in constraint-path updated-constraint)
+       add-code? (update-in [:qb :constraint-logic] append-code (symbol (:code updated-constraint)))
+       remove-code? (update-in [:qb :constraint-logic] remove-code (symbol (:code constraint)))))))
 
 (reg-event-db
  :qb/enhance-query-clear-query


### PR DESCRIPTION
See commit text for details.

The change to `satisfied-constraint?` also affects templates, so that they won't attempt to run if you change a constraint to be blank.