### PR TITLE
Include semantic markup in HTML

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                  [org.clojure/clojure "1.10.1"]
                  [org.clojure/clojurescript "1.10.520"]
                  [org.clojure/core.async "1.0.567"]
+                 [org.clojure/core.cache "0.8.2"]
 
                  ; MVC
                  [re-frame "0.12.0"]

--- a/project.clj
+++ b/project.clj
@@ -79,7 +79,7 @@
 
                  ; Intermine Assets
                  [org.intermine/im-tables "0.11.0"]
-                 [org.intermine/imcljs "1.3.2"]
+                 [org.intermine/imcljs "1.4.0"]
                  [org.intermine/bluegenes-tool-store "0.2.0"]]
 
   :deploy-repositories {"clojars" {:sign-releases false}}

--- a/src/clj/bluegenes/index.clj
+++ b/src/clj/bluegenes/index.clj
@@ -2,7 +2,8 @@
   (:require [hiccup.page :refer [include-js include-css html5]]
             [config.core :refer [env]]
             [cheshire.core :refer [generate-string]]
-            [bluegenes.utils :as utils]))
+            [bluegenes.utils :as utils]
+            [imcljs.fetch :as im-fetch]))
 
 ;; Hello dear maker of the internet. You want to edit *this* file for prod,
 ;; NOT resources/public/index.html.
@@ -26,8 +27,10 @@
 
 (defn head
   ([]
-   (head nil))
+   (head nil {}))
   ([init-vars]
+   (head init-vars {}))
+  ([init-vars options]
    [:head
     loader-style
     css-compiling-style
@@ -63,7 +66,14 @@
               :src "https://code.jquery.com/jquery-3.1.0.min.js"}]
     [:script {:crossorigin "anonymous"
               :src "https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"}]
-    [:script {:src "https://apis.google.com/js/api.js"}]]))
+    [:script {:src "https://apis.google.com/js/api.js"}]
+    (when-let [semantic-markup-type (:semantic-markup options)]
+      (let [service {:root (get-in options [:mine :root])}]
+        [:script {:type "application/ld+json"}
+         (generate-string
+           (case semantic-markup-type
+             :home (im-fetch/semantic-markup service "homepage")
+             :report (im-fetch/semantic-markup service "reportpage" {:id (:object-id options)})))]))]))
 
 (defn loader []
   [:div#wrappy
@@ -88,10 +98,12 @@
 (defn index
   "Hiccup markup that generates the landing page and loads the necessary assets."
   ([]
-   (index nil))
+   (index nil {}))
   ([init-vars]
+   (index init-vars {}))
+  ([init-vars options]
    (html5
-    (head init-vars)
+    (head init-vars options)
     [:body
      (css-compiler)
      (loader)

--- a/src/clj/bluegenes/utils.clj
+++ b/src/clj/bluegenes/utils.clj
@@ -55,3 +55,18 @@
             :name (:bluegenes-default-mine-name env)
             :namespace (:bluegenes-default-namespace env)}]
           (:bluegenes-additional-mines env)))
+
+(defn- timeout
+  [req]
+  (assoc req
+         :socket-timeout 3000
+         :connection-timeout 3000))
+
+(defn wrap-timeout
+  "Middleware which adds a short timeout to the request."
+  [client]
+  (fn
+    ([req]
+     (client (timeout req)))
+    ([req respond raise]
+     (client (timeout req) respond raise))))

--- a/src/clj/bluegenes/utils.clj
+++ b/src/clj/bluegenes/utils.clj
@@ -46,3 +46,12 @@
   "Rename a path ending with filename 'foo.css' to 'foo-<fingerprint>.css'"
   [file-path fingerprint]
   (str/replace file-path #"\.css$" (str "-" fingerprint ".css")))
+
+(defn env->mines
+  "Parses env to return a vector of configured mines.
+  Guarantees first mine to always be default."
+  [env]
+  (concat [{:root (:bluegenes-default-service-root env)
+            :name (:bluegenes-default-mine-name env)
+            :namespace (:bluegenes-default-namespace env)}]
+          (:bluegenes-additional-mines env)))


### PR DESCRIPTION
On an initial HTTP request (this excludes URL changes done by the frontend webapp) to root, `/minename`, or a report page on minename (where minename is a configured mine's namespace), the Bluegenes backend will fetch the page's semantic markup and include it as ld+json in the response HTML. This should ensure that the Bioschema crawler picks it up.

As this would otherwise delay the initial HTTP response, caching has been enabled, (clearing the cache requires restarting Bluegenes) as well as a short timeout of 3 seconds for the request to the semantic markup web service. Note that this only applies to the configured mine(s) (specified in config.edn or through envvars) and not any registry mine.

Fixes #430

**Warning: Do not merge before dependent imcljs functions are released.**