### PR TITLE
Implement feedback form functionality on homepage

### DIFF
--- a/less/components/home.less
+++ b/less/components/home.less
@@ -369,6 +369,16 @@
                 background: lighten(@body-foreground-color,13%);
             }
         }
+
+        &-response {
+            text-align: center;
+            margin-bottom: @spacer*6.5;
+
+            .icon {
+                fill: @success-text-color;
+                font-size: 5em;
+            }
+        }
     }
 
     .credits-fallback {

--- a/project.clj
+++ b/project.clj
@@ -79,7 +79,7 @@
 
                  ; Intermine Assets
                  [org.intermine/im-tables "0.11.0"]
-                 [org.intermine/imcljs "1.3.2"]
+                 [org.intermine/imcljs "1.4.0"]
                  [org.intermine/bluegenes-tool-store "0.2.0"]]
 
   :deploy-repositories {"clojars" {:sign-releases false}}

--- a/src/cljs/bluegenes/pages/home/subs.cljs
+++ b/src/cljs/bluegenes/pages/home/subs.cljs
@@ -9,6 +9,12 @@
    (:home db)))
 
 (reg-sub
+ :home/feedback-response
+ :<- [:home/root]
+ (fn [home]
+   (:feedback-response home)))
+
+(reg-sub
  :home/active-template-category
  :<- [:home/root]
  (fn [home]

--- a/src/cljs/bluegenes/route.cljs
+++ b/src/cljs/bluegenes/route.cljs
@@ -150,6 +150,7 @@
      {:name ::home
       :controllers
       [{:start (fn []
+                 (dispatch [:home/clear])
                  (dispatch [:set-active-panel :home-panel
                             nil
                             [:bluegenes.events.blog/fetch-rss]]))}]}]


### PR DESCRIPTION
Previously, it would just show an alert saying we hadn't implemented it yet. Now it will use the new feedback web service.

Fixes #553

**Warning: Do not merge before dependent imcljs functions are released.**
