### PR TITLE
Seamlessly update page on login/logout

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                   :exclusions [cljsjs/react cljsjs/react-dom]]
                  [hiccup "1.0.5"]
                  [prismatic/dommy "1.1.0"]
-                 [metosin/reitit "0.4.2"]
+                 [metosin/reitit "0.5.12"]
                  [servant "0.1.5"]
                  [json-html "0.4.7"]
                  [markdown-to-hiccup "0.6.2"]

--- a/src/cljs/bluegenes/events.cljs
+++ b/src/cljs/bluegenes/events.cljs
@@ -40,7 +40,8 @@
 ;; as argument and its return value decides whether the panel will be changed.
 (let [requirements
       {:profile-panel #(map? (get-in % [:mines (:current-mine %) :auth :identity]))
-       :admin-panel #(get-in % [:mines (:current-mine %) :auth :identity :superuser])}]
+       :admin-panel #(get-in % [:mines (:current-mine %) :auth :identity :superuser])
+       :reset-password-panel #(empty? (get-in % [:mines (:current-mine %) :auth :identity]))}]
   ;; Change the main panel to a new view.
   (reg-event-fx
    :do-active-panel
@@ -60,12 +61,15 @@
            ;; Dispatch any events paired with the panel change.
            evt (assoc :dispatch evt))
          {:dispatch-n [[::route/navigate ::route/home]
-                       [:messages/add
-                        {:markup (case active-panel
-                                   :profile-panel [:span "You need to be logged in to access this page."]
-                                   :admin-panel [:span "You need to be a superuser to access this page."]
-                                   [:span "You don't have access to this page."])
-                         :style "warning"}]]})))))
+                       (case active-panel
+                         ;; When you login while on the reset password page, just change to home page.
+                         :reset-password-panel nil
+                         [:messages/add
+                          {:markup (case active-panel
+                                     :profile-panel [:span "You need to be logged in to access this page."]
+                                     :admin-panel [:span "You need to be a superuser to access this page."]
+                                     [:span "You don't have access to this page."])
+                           :style "warning"}])]})))))
 
 ; A buffer between booting and changing the view. We only change the view
 ; when the assets have been loaded

--- a/src/cljs/bluegenes/events/auth.cljs
+++ b/src/cljs/bluegenes/events/auth.cljs
@@ -55,6 +55,11 @@
               ;; We clear it here as otherwise all the lists belonging to the
               ;; user will be annotated as new.
               (update-in [:lists :by-id] empty)
+              ;; Since both :assets/fetch-lists and start-router is run below,
+              ;; this causes lists to be denormalized based on previous list
+              ;; data when router starts, and for it to get updated when lists
+              ;; are fetched, causing user lists to be marked as new.
+              (update-in [:assets :lists current-mine] empty)
               (route/force-controllers-rerun))
       :dispatch-n [[:save-login current-mine identity]
                    [:assets/fetch-lists]

--- a/src/cljs/bluegenes/events/auth.cljs
+++ b/src/cljs/bluegenes/events/auth.cljs
@@ -54,11 +54,14 @@
               ;; The old by-id map is used to detect newly added lists.
               ;; We clear it here as otherwise all the lists belonging to the
               ;; user will be annotated as new.
-              (update-in [:lists :by-id] empty))
+              (update-in [:lists :by-id] empty)
+              (route/force-controllers-rerun))
       :dispatch-n [[:save-login current-mine identity]
                    [:assets/fetch-lists]
                    (when (seq ?renamedLists)
-                     (renamedLists->message ?renamedLists))]})))
+                     (renamedLists->message ?renamedLists))
+                   ;; Restart router to rerun controllers.
+                   [:bluegenes.events.boot/start-router]]})))
 
 (reg-event-db
  ::login-failure
@@ -96,9 +99,12 @@
                          :identity nil
                          :error? false
                          :message nil)
-              (assoc-in [:mines current-mine :service :token] nil))
+              (assoc-in [:mines current-mine :service :token] nil)
+              (route/force-controllers-rerun))
       :dispatch-n [[:remove-login current-mine]
-                   [::route/navigate ::route/home]
+                   ;; We could optimize this by not doing a reboot (it's likely
+                   ;; only authentication and restarting the router we have to do)
+                   ;; but logging out should be uncommon enough to not warrant it.
                    [:reboot]]})))
 
 (reg-event-fx

--- a/src/cljs/bluegenes/route.cljs
+++ b/src/cljs/bluegenes/route.cljs
@@ -113,6 +113,8 @@
  (fn [_]
    (.back js/window.history)))
 
+;;; Utility functions ;;;
+
 (defn href
   "Return relative url for given route. Url can be used in HTML links."
   ([k]
@@ -122,6 +124,16 @@
   ([k params query]
    (let [current-mine (subscribe [:current-mine-name])]
      (rfe/href k (update params :mine #(or % @current-mine)) query))))
+
+(defn force-controllers-rerun
+  "Force controllers to rerun on the next router start or navigation, whichever
+  comes first. This would be equivalent to the URL path changing to blank, and
+  then to the new path (which would be the same path in the case of a router start).
+  Depends on an implementation detail of reitit.frontend.controllers/apply-controllers,
+  wherein it does a simple equality check of the controller maps before applying."
+  [db]
+  (update-in db [:current-route :controllers]
+             (partial mapv #(assoc % ::force-rerun true))))
 
 ;; The majority of the routes fire a `:set-active-panel` but ours is slightly
 ;; different from what's in the re-frame boilerplate. Our `:set-active-panel`

--- a/test/cljs/bluegenes/events_test.cljs
+++ b/test/cljs/bluegenes/events_test.cljs
@@ -37,6 +37,8 @@
 (deftest reuse-login-token
   (run-test-sync
    (utils/stub-local-storage)
+   ;; Starting the router causes a crash here, so change it to noop.
+   (rf/reg-event-fx :bluegenes.events.boot/start-router (fn [] {}))
    (with-redefs [fetch/lists    (utils/stub-fetch-fn [])
                  auth/who-am-i? (utils/stub-fetch-fn {})
                  config/init-vars (delay nil)]


### PR DESCRIPTION
We found that redirecting to homepage can be quite annoying, and instead should have the current page seamlessly update with the correct data when logging in or out. This is made possible with `route/force-controllers-rerun` followed by restarting the router, which causes the controllers for the page (responsible for acquiring the required data) to be rerun.

The remaining commits is then to fix bugs that appeared following this. I have reviewed all the controllers and tested the pages, so hopefully there's no more bugs hidden.

Closes #485