### PR TITLE
Allow tools to set threshold for automatic loading

### DIFF
--- a/docs/tools/tool-api.md
+++ b/docs/tools/tool-api.md
@@ -140,6 +140,7 @@ This file provides bluegenes-specific config info. Some further config info is d
     "css": "dist/style.css",
     "js": "dist/bundle.js"
   },
+  "threshold": 100,
   "toolName": {
     "human": "Protein Features",
     "cljs": "proteinFeatures"
@@ -167,6 +168,8 @@ Plurality (i.e. id vs ids) will help to determine which context a tool can appea
 **depends** lets you specify any class names in the InterMine instance's model that your tool depends on. This is useful if you're querying for a non-standard path that is only present in a specific InterMine instance. Any instances which don't have the class name in their model will not attempt to run your tool, and will instead, list it as unsupported.
 
 **files** - one file each for css and js, please. This should be the file bundled/built with all dependencies except/ imjs if needed. CSS is optional if the tool has no styles.
+
+**threshold** is the greatest count of objects your tool will automatically load for. This will be matched against the imEntity with the highest amount of `value` elements. If your tool becomes very resource intensive or its visualization becomes very crowded, when the amount of objects reach a certain threshold, you should set this to an appropriate number. The tool will still be present, although it will stay collapsed with a message explaining to the user that there are too many results and they can click to load the tool. If this property isn't set, BlueGenes will default to 1000 (this means you can set a higher threshold if you wish to override it).
 
 **toolName** is an object with a human-readable name, as well as an internal name. The human name would be what you want to see as a header for this tool (e.g. ProtVista might be called "Protein Features"). The internal `cljs` name needs to be unique among tools and identical to the global JS variable which your tool's bundle initialises.
 

--- a/less/components/report.less
+++ b/less/components/report.less
@@ -466,6 +466,16 @@
         }
     }
 
+    &-threshold {
+        padding: @spacer/4 @spacer/2;
+        position: absolute;
+        left: 50%;
+        transform: translateX(-50%);
+        background-color: @extra-color-text;
+        color: @extra-color-background;
+        border-radius: 4px;
+    }
+
     &-toggle {
         fill: @extra-color-text;
     }

--- a/src/cljs/bluegenes/components/tools/effects.cljs
+++ b/src/cljs/bluegenes/components/tools/effects.cljs
@@ -114,8 +114,9 @@
 ;; In the latter case, it will merely call the tool's main function.
 (reg-fx
  :load-tool
- (fn [{:keys [tool tool-id service hier entities]}]
+ (fn [{:keys [tool tool-id service]}]
    ;; `entity` is nil if tool is not suitable to be displayed.
-   (when-let [entity (suitable-entities (get-in service [:model :classes]) hier entities (:config tool))]
+   ;; Although this shouldn't be called if that's the case.
+   (when-let [entity (:entity tool)]
      (fetch-script! tool tool-id :service service :entity entity)
      (fetch-styles! tool tool-id))))

--- a/src/cljs/bluegenes/components/tools/events.cljs
+++ b/src/cljs/bluegenes/components/tools/events.cljs
@@ -79,14 +79,10 @@
  ::init-tool
  (fn [{db :db} [_ tool-details tool-id]]
    (let [mine     (get-in db [:mines (:current-mine db)])
-         hier     (get mine :model-hier)
-         service  (get mine :service)
-         entities (get-in db [:tools :entities])]
+         service  (get mine :service)]
      {:load-tool {:tool tool-details
                   :tool-id tool-id
-                  :service service
-                  :hier hier
-                  :entities entities}})))
+                  :service service}})))
 
 (reg-event-db
  ::collapse-tool

--- a/src/cljs/bluegenes/components/tools/subs.cljs
+++ b/src/cljs/bluegenes/components/tools/subs.cljs
@@ -49,7 +49,10 @@
  :<- [:results/entities-ready?]
  (fn [[tools entities model hier ready?]]
    (when ready?
-     (filter #(suitable-entities model hier entities (:config %)) tools))))
+     (keep (fn [tool]
+             (when-let [entity (suitable-entities model hier entities (:config tool))]
+               (assoc tool :entity entity)))
+           tools))))
 
 (reg-sub
  ::collapsed-tool?

--- a/src/cljs/bluegenes/components/tools/views.cljs
+++ b/src/cljs/bluegenes/components/tools/views.cljs
@@ -61,6 +61,9 @@
            (when description [description-dropdown description])
            [poppable {:data [:span "This is a visualization and may take longer to load. If you click to collapse, it will stay hidden on all pages until you expand it again."]
                       :children [icon "bar-chart"]}]]
+          (when threshold-halted?
+            [:span.report-item-threshold
+             "Results exceed recommended amount for this tool - you can still load it by clicking this header"])
           [:span.report-item-toggle
            (if collapsed?
              [icon "expand-folder"]

--- a/src/cljs/bluegenes/components/tools/views.cljs
+++ b/src/cljs/bluegenes/components/tools/views.cljs
@@ -3,11 +3,23 @@
             [reagent.core :as reagent]
             [bluegenes.components.tools.subs :as subs]
             [bluegenes.components.tools.events :as events]
-            [clojure.string :as str]
             [bluegenes.components.icons :refer [icon]]
             [bluegenes.components.bootstrap :refer [poppable]]
             [bluegenes.utils :refer [clean-tool-name]]
             [bluegenes.pages.reportpage.utils :refer [description-dropdown]]))
+
+(def global-threshold 1000)
+
+(defn greatest-count
+  "Returns the greatest count of IDs across all entities."
+  [entities]
+  (apply max (map (comp #(if (coll? %) (count %) 1) :value val) entities)))
+
+(defn above-threshold?
+  "Returns whether a tool has surpassed its config's specified threshold, or
+  the global threshold, for automatic initialisation."
+  [{:keys [entity config] :as _tool-details}]
+  (> (greatest-count entity) (:threshold config global-threshold)))
 
 ;; The following component may be used by itself to display one tool.
 (defn tool [{{:keys [cljs]} :names :as tool-details} & {:keys [collapse id]}]
@@ -20,15 +32,15 @@
     ;; id is either a symbol, when this tool is on the report page;
     ;; or nil, when this tool is on the results page.
 
-    (when-not (or collapse @collapsed-tool?)
+    (when-not (or collapse @collapsed-tool? (above-threshold? tool-details))
       (dispatch [::events/init-tool tool-details tool-id]))
 
     (fn [{{:keys [cljs human]} :names :as tool-details} & {:keys [collapse id description]}]
-      (let [collapsed? (or @collapsed-tool?
+      (let [threshold-halted? (if @override-collapse* false (above-threshold? tool-details))
+            collapsed? (or @collapsed-tool?
+                           threshold-halted?
                            (and (not @override-collapse*)
                                 collapse))]
-        ;; Please avoid changing the markup that follows. Its structure is
-        ;; copied to each tool's demo.html so they get a similar styling.
         [:div.report-item
          {:class (when collapsed? :report-item-collapsed)
           :id id}
@@ -36,12 +48,13 @@
           {:on-click (fn []
                        ;; Only init the tool if it had been initially collapsed
                        ;; (and therefore not previously initialised).
-                       (when (and (or collapse @collapsed-tool?)
+                       (when (and (or collapse @collapsed-tool? threshold-halted?)
                                   (not @override-collapse*))
                          (dispatch [::events/init-tool tool-details tool-id]))
-                       (if collapsed?
-                         (dispatch [::events/expand-tool cljs])
-                         (dispatch [::events/collapse-tool cljs]))
+                       (when-not threshold-halted?
+                         (if collapsed?
+                           (dispatch [::events/expand-tool cljs])
+                           (dispatch [::events/collapse-tool cljs])))
                        (reset! override-collapse* true))}
           [:span.report-item-title
            (clean-tool-name human)

--- a/src/cljs/bluegenes/components/tools/views.cljs
+++ b/src/cljs/bluegenes/components/tools/views.cljs
@@ -43,7 +43,7 @@
                                 collapse))]
         [:div.report-item
          {:class (when collapsed? :report-item-collapsed)
-          :id id}
+          :id (or id (str tool-id "-container"))}
          [:h4.report-item-heading
           {:on-click (fn []
                        ;; Only init the tool if it had been initially collapsed

--- a/src/cljs/bluegenes/pages/reportpage/views.cljs
+++ b/src/cljs/bluegenes/pages/reportpage/views.cljs
@@ -67,8 +67,11 @@
                                :id objectId}))}})
 
 (defn tool-report [{:keys [collapse id description] tool-cljs-name :value}]
-  (let [tool-details @(subscribe [::subs/a-tool tool-cljs-name])]
-    [tools/tool tool-details
+  (let [tool-details @(subscribe [::subs/a-tool tool-cljs-name])
+        ;; The line below relies on the fact that a report page is always one entity.
+        ;; If there could be multiple, we'd have to use `utils/suitable-entities`.
+        entity @(subscribe [:bluegenes.components.tools.subs/entities])]
+    [tools/tool (assoc tool-details :entity entity)
      :collapse collapse
      :id id
      :description description]))

--- a/src/cljs/bluegenes/pages/results/views.cljs
+++ b/src/cljs/bluegenes/pages/results/views.cljs
@@ -160,7 +160,7 @@
     (let [current-scroll (clj->js ((juxt #(oget % :x) #(oget % :y)) (gdom/getDocumentScroll)))
           target-scroll (if (nil? id)
                           #js [0 0] ; Scroll to top if no ID specified.
-                          (clj->js ((juxt #(- (oget % :x) 135) #(- (oget % :y) 135))
+                          (clj->js ((juxt #(- (oget % :x) 80) #(- (oget % :y) 80))
                                     (gstyle/getRelativePosition elem (gdom/getDocumentScrollElement)))))]
       (doto (gfx/Scroll. (gdom/getDocumentScrollElement)
                          current-scroll
@@ -178,7 +178,7 @@
               "Top"]]
             (for [{:keys [cljs human]} tool-names]
               [:span.jump-item
-               {:on-click #(scroll-into-view! cljs)}
+               {:on-click #(scroll-into-view! (str cljs "-container"))}
                (clean-tool-name human)])))))
 
 (defn main

--- a/src/cljs/bluegenes/route.cljs
+++ b/src/cljs/bluegenes/route.cljs
@@ -246,11 +246,12 @@
       :controllers
       [{:parameters {:path [:mine :type :id]}
         :start (fn [{{:keys [mine type id]} :path}]
-                 (dispatch [:clear-ids-tool-entity])
-                 (dispatch [:viz/clear])
-                 (dispatch [:set-active-panel :reportpage-panel
-                            {:type type, :id id, :format "id", :mine mine}
-                            [:load-report mine type id]]))
+                 (let [id (js/parseInt id 10)]
+                   (dispatch [:clear-ids-tool-entity])
+                   (dispatch [:viz/clear])
+                   (dispatch [:set-active-panel :reportpage-panel
+                              {:type type, :id id, :format "id", :mine mine}
+                              [:load-report mine type id]])))
         :stop #(dispatch [:bluegenes.pages.reportpage.events/stop-scroll-handling])}]}]
     ["/share/:lookup"
      {:name ::share


### PR DESCRIPTION
Adds a new *threshold* key to the Tool API config.json, so that tools can set the threshold for which they are loaded automatically on the results page, based on the amount of objects passed to the tool (does not apply to report page as tools are only passed 1 object there). Defaults to 1000 if not set.

Fixes #630
