### PR TITLE
fix: remove support , fixtures and plugins from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,7 @@
 /resources/public/css
 /resources/public/tools/*
 /cypress/screenshots
-/cypress/plugins
 /cypress/videos
-/cypress/support
-/cypress/fixtures
 /cypress/results
 config/**/*.edn
 !config/defaults/config.edn


### PR DESCRIPTION

- I have restored cypress support, fixtures folder
- I have not created an issue for this
- No explicit tests needed, the following folders are core to cypress as they have all got different usages. I don't think we should ignore them as they are helpers for cypress main tests.
