### PR TITLE
enh: add cypress retries and env variables

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,5 +5,14 @@
     "reporterOptions": {
       "mochaFile": "cypress/results/output.xml",
       "toConsole": true
+    },
+    "retries": {
+      "runMode": 2,
+      "openMode": 2
+    },
+    "env": {
+      "BLUEGENES_DEFAULT_MINE_NAME": "biotestmine",
+      "BLUEGENES_DEFAULT_NAMESPACE": "biotestmine",
+      "BLUEGENES_DEFAULT_SERVICE_ROOT": "http://localhost:9999/biotestmine"
     }
 }


### PR DESCRIPTION
Signed-off-by: Meenal Trivedi <meenaltrivedi6102@gmail.com>

- added cypress retries in ci and local machine, as well as setted up env vars.
- fixes #702 
